### PR TITLE
Reorder batch retrieved entities according to their provided ids

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -88,6 +88,12 @@
                     return _this.__model(e.data, null, null, null, e.key);
                 });
 
+                if (entity.length > 1) {
+                    entity.sort(function(a, b){
+                        return id.indexOf(a.entityKey.id) - id.indexOf(b.entityKey.id);
+                    });
+                }
+
                 cb(null, multiple ? entity : entity[0]);
             }
         }


### PR DESCRIPTION
When an array of entity IDs is passed to `Model.get()`, the results are scrambled and never in the order of the IDs passed into the function. This is actually on google-cloud's side, not gstore-node, but this fixes it.

The biggest use case for this is that most production applications will perform large keys-only queries, sort out the unnecessary ones, and later retrieve the entities by keys. If the queries are sorted, they will lose all sorting when later retrieved. 

This fixes all of that when entities are retrieved through gstore. I don't particularly think Google cares about this issue, but an issue submission on their side might eliminate the need to fix it on our side.