### PR TITLE
Add preserveOrder option to Model.get()

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ This method accepts the following parameters:
 - ancestors {Array} (optional)
 - namespace (optional)
 - transaction (optional)
+- options (optional)
 - callback
 
 Returns: an entity **instance**.
@@ -399,6 +400,11 @@ transaction.run(function(err) {
     });
 });
 ```
+
+**preserveOrder** property (options)
+The options parameter has a **preserveOrder** property (default to false) that, if set to true, will retain the order of result entities as they were passed in. For example, getting IDs `[1, 2, 3]` will return in that order when **preserveOrder** is set. Otherwise, the order is undefined.
+
+Setting this to true does take some processing, especially for large sets. Only use it if you need the results in a certain order.
 
 #### Update()
 To update a Model, call `Model.update(...args);`

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ sometimes lead to a lot of duplicate code to **validate** the properties passed 
  ```
 
 ### Getting started
-For info on how to configure gcloud [read the docs here](https://googlecloudplatform.github.io/gcloud-node/#/docs/v0.37.0/gcloud?method=gcloud).
+For info on how to configure gcloud [read the docs here](https://googlecloudplatform.github.io/google-cloud-node/#/docs/google-cloud/0.40.0/google-cloud?method=gcloud).
 
  ```js
  var configGcloud = {...your config here};

--- a/lib/model.js
+++ b/lib/model.js
@@ -43,7 +43,7 @@
             return ModelInstance;
         }
 
-        static get(id, ancestors, namespace, transaction, cb) {
+        static get(id, ancestors, namespace, transaction, options, cb) {
             let _this = this;
             let args  = arrayArguments(arguments);
             let multiple = is.array(id);
@@ -53,6 +53,7 @@
             ancestors   = args.length > 1 ? args[1] : undefined;
             namespace   = args.length > 2 ? args[2] : undefined;
             transaction = args.length > 3 ? args[3] : undefined;
+            options     = args.length > 4 ? args[4] : {};
 
             let key     = this.key(id, ancestors, namespace);
 
@@ -87,7 +88,7 @@
                     return _this.__model(e.data, null, null, null, e.key);
                 });
 
-                if (entity.length > 1) {
+                if (entity.length>1 && options.preserveOrder) {
                     entity.sort(function(a, b){
                         return id.indexOf(a.entityKey.id) - id.indexOf(b.entityKey.id);
                     });


### PR DESCRIPTION
Added **preserveOrder** option to `Model.get()` with default to `false`. Code examples may still need to be updated, I can do that soon.

@sebelga sorry it took so long!