### PR TITLE
Fixed incorrect behaviour when update array

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -164,7 +164,7 @@
                         return;
                     }
 
-                    extend(true, entity.data, data);
+                    extend(false, entity.data, data);
 
                     save(entity.key, entity.data, transaction, done);
                 });


### PR DESCRIPTION
Incorrect update array in object cause from deep extend 

For example 
Original data : {name: "Hello world",  addresses: ["address1", "address2"]}
Update data: {addresses: ["address2"]}

Expected result: {name: "Hello world",  addresses: ["address2"]}
Current result: {name: "Hello world",  addresses: ["address2", "address2"]}