### PR TITLE
Added virtual properties for all fields defined in the schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,6 +726,31 @@ var blogPost = new BlogPost(data, null, null, 'dev-com.my-domain');
 - **entityData**. The properties data of the entity.
 - **entityKey**. The entity key saved in the Datastore.
 
+Based on the definition of the schema, virtual properties are automatically added on the Entity objects to retrieve the values from the entityData directly.
+This means there are two ways you can access the data of an Entity: via entity.entityData or direct on entity itself. For example:
+
+```js
+var gstore = require('gstore-node');
+
+var blogPostSchema = new gstore.Schema({
+    title :     {type:'string'},
+    createdOn : {type:'datetime', default:new Date()}
+});
+
+var BlogPost = gstore.model('BlogPost', blogPostSchema);
+
+var data = {
+    title : 'My first blog post'
+};
+var blogPostEntity = new BlogPost(data);
+
+// Logs the same value 'My first blog post'
+console.log(blogPostEntity.title);
+console.log(blogPostEntity.entityData.title);
+
+blogPostEntity.title = 'My second blog post'; // blogPostEntity.entityData.title is also changed
+blogPostEntity.entityData.title = 'My third blog post'; // blogPostEntity.title is also changed
+```
 
 ### Methods
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -40,6 +40,17 @@
             ModelInstance.hooks                = schema.s.hooks.clone();
             ModelInstance.prototype.gstore     = ModelInstance.gstore = gstore;
 
+            Object.keys(schema.paths)
+                .filter((key) => schema.paths.hasOwnProperty(key))
+                .forEach((key) => Object.defineProperty(ModelInstance.prototype, key, {
+                    get: function() {
+                        return this.entityData[key];
+                    },
+                    set: function(new_value) {
+                        this.entityData[key] = new_value;
+                    }
+                }));
+
             return ModelInstance;
         }
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -173,8 +173,14 @@
     };
 
     const reserved = {
+        constructor:true,
         ds:true,
+        gstore:true,
         entityKey:true,
+        entityData:true,
+        className:true,
+        domain:true,
+        excludeFromIndexes:true,
         emit:true,
         on:true,
         once:true,
@@ -191,10 +197,17 @@
         set:true,
         toObject:true,
         validate:true,
+        hook:true,
         pre:true,
         post:true,
-        _pre:true,
-        _post:true
+        removePre:true,
+        removePost:true,
+        _pres:true,
+        _posts:true,
+        _events:true,
+        _eventsCount:true,
+        _lazySetupHooks:true,
+        _maxListeners:true
     };
 
     module.exports = exports = Schema;

--- a/test/entity-test.js
+++ b/test/entity-test.js
@@ -103,20 +103,6 @@ describe('Entity', () => {
             expect(entity.entityData.email).equal(undefined);
         });
 
-        it('should add entity properties for fields defined in the schema', () => {
-            let model = gstore.model('BlogPost', schema);
-
-            let entity = new model({
-                name: 'Jane',
-                lastname: 'Does',
-                password: 'jane@does.com'
-            });
-
-            expect(entity.name).to.exist;
-            expect(entity.lastname).to.exist;
-            expect(entity.password).to.exist;
-        });
-
         it('should call handler for default values in gstore.defaultValues constants', () => {
             clock.restore();
             sinon.spy(gstore.defaultValues, '__handler__');

--- a/test/entity-test.js
+++ b/test/entity-test.js
@@ -103,6 +103,20 @@ describe('Entity', () => {
             expect(entity.entityData.email).equal(undefined);
         });
 
+        it('should add entity properties for fields defined in the schema', () => {
+            let model = gstore.model('BlogPost', schema);
+
+            let entity = new model({
+                name: 'Jane',
+                lastname: 'Does',
+                password: 'jane@does.com'
+            });
+
+            expect(entity.name).to.exist;
+            expect(entity.lastname).to.exist;
+            expect(entity.password).to.exist;
+        });
+
         it('should call handler for default values in gstore.defaultValues constants', () => {
             clock.restore();
             sinon.spy(gstore.defaultValues, '__handler__');
@@ -343,6 +357,38 @@ describe('Entity', () => {
             user.set('fullname', 'Peter Jackson');
 
             expect(user.entityData.name).equal('Peter');
+        });
+
+        it('should get data on entity properties from the entity data', () => {
+            let model = gstore.model('BlogPost', schema);
+
+            let entity = new model({
+                name: 'Jane',
+                lastname: 'Does',
+                password: 'JanesPassword'
+            });
+
+            expect(entity.name).to.equal('Jane');
+            expect(entity.lastname).to.equal('Does');
+            expect(entity.password).to.equal('JanesPassword');
+        });
+
+        it('should reflect changes to entity properties in the entity data', () => {
+            let model = gstore.model('BlogPost', schema);
+
+            let entity = new model({
+                name: 'Jane',
+                lastname: 'Does',
+                password: 'JanesPassword'
+            });
+
+            entity.name = 'John';
+            entity.lastname = 'Doe';
+            entity.password = 'JoesPassword';
+
+            expect(entity.entityData.name).to.equal('John');
+            expect(entity.entityData.lastname).to.equal('Doe');
+            expect(entity.entityData.password).to.equal('JoesPassword');
         });
     });
 


### PR DESCRIPTION
I've added some logic to create virtual properties for each of the fields in the schema. This way I can access properties directly via MyModel.myProperty instead of MyModel.entityData.myProperty, same as can be done in Mongoose