### PR TITLE
Fix `.get()` with single-item array

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -108,7 +108,8 @@ class Model extends Entity {
     static get(id, ancestors, namespace, transaction, options, cb) {
         const _this = this;
         const args = Array.prototype.slice.apply(arguments);
-        const multiple = is.array(id);
+        const array = is.array(id);
+        const num = array ? id.length : 1;
 
         cb = args.pop();
         id = parseId(id);
@@ -142,17 +143,17 @@ class Model extends Entity {
 
             let entity = data[0];
 
-            if (!multiple) {
+            if (!array || num == 1) {
                 entity = [entity];
             }
 
             entity = entity.map(e => _this.__model(e, null, null, null, e[_this.gstore.ds.KEY]));
 
-            if (multiple && options.preserveOrder) {
+            if (array && options.preserveOrder) {
                 entity.sort((a, b) => id.indexOf(a.entityKey.id) - id.indexOf(b.entityKey.id));
             }
 
-            const response = multiple ? entity : entity[0];
+            const response = array ? entity : entity[0];
             return cb(null, response);
         }
 


### PR DESCRIPTION
Hey buddy, it's been a while.

There is currently an issue when passing an array into `Model.get()` with just one element. It's recognized as an array, but `parseId()` transforms it from `[123123123]` to just `123123123`. This causes an error to be thrown because it is never successfully converted back to an array while it tries to use array methods such as `.map()`

This can be a common occurrence in the case that a developer passes an array of IDs returned from a keys-only query.

Hope you're doing well, Sebastien!