### PR TITLE
Adds support for multiple arguments in the validation function, fixes issue #38

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,21 @@ var entitySchema = new Schema({
 });
 ```
 
+If you need to use a function that requires extra arguments (e.g. [isIP](https://github.com/chriso/validator.js#validators)), you can define the `validate` in the following way:
+
+```js
+var entitySchema = new Schema({
+  // ...
+  ip  : {
+    validate: {
+      rule: 'isIP',
+      args: [4]
+    },
+  }
+});
+```
+This way, the `args` item will be passed to the as 3rd argument on the `isIP` validation function, accepting only IPs of IPv4 type.
+
 You can also define an **Array of valid values** for a properties.  
 If you then try to save an entity with a different value it won't validate and won't be saved in the Datastore.
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -972,12 +972,35 @@ class Model extends Entity {
             }
 
             // ...Wrong format
-            if (!skip && schemaHasProperty && !isValueEmpty &&
-                    {}.hasOwnProperty.call(schema.paths[k], 'validate') &&
-                    !validator[schema.paths[k].validate](propertyValue)) {
-                errors[k] = new GstoreError.ValidatorError({
-                    message: `Wrong format for property { ${k} }`,
-                });
+            if (
+                !skip && schemaHasProperty && !isValueEmpty &&
+                {}.hasOwnProperty.call(schema.paths[k], 'validate')
+            ) {
+                /**
+                 * By default, the args only contain the value being validated
+                 * and the string, matching the simple case.
+                 */
+                let validationArgs = [propertyValue];
+                let validationRule = schema.paths[k].validate;
+
+                /**
+                 * If the validate property is an object, then it's assumed that
+                 * it contains the 'rule' property, which will be the new
+                 * validationRule's value.
+                 * If the 'args' prop was passed then we concat them to
+                 * 'validationArgs'.
+                 */
+                if (typeof validationRule === 'object') {
+                    validationRule = schema.paths[k].validate.rule;
+                    validationArgs = validationArgs.concat(schema.paths[k].validate.args || []);
+                }
+
+                /** Then it gets easier to use 'apply' on both simple and complex cases */
+                if (!validator[validationRule].apply(validator, validationArgs)) {
+                    errors[k] = new GstoreError.ValidatorError({
+                        message: `Wrong format for property { ${k} }`,
+                    });
+                }
             }
 
             // ...Preset values

--- a/test/model-test.js
+++ b/test/model-test.js
@@ -47,6 +47,7 @@ describe('Model', () => {
             street: {},
             website: { validate: 'isURL' },
             email: { validate: 'isEmail' },
+            ip: { validate: { rule: 'isIP', args: [4] } },
             modified: { type: 'boolean' },
             tags: { type: 'array' },
             prefs: { type: 'object' },
@@ -1875,6 +1876,25 @@ describe('Model', () => {
             expect(valid2.success).equal(false);
             expect(valid3.success).equal(false);
             expect(valid4.success).equal(false);
+        });
+
+        it('--> is IP ok', () => {
+            const model = new ModelInstance({ ip: '127.0.0.1' });
+
+            const valid = model.validate();
+
+            expect(valid.success).equal(true);
+        });
+
+        it('--> is IP ko', () => {
+            const model = new ModelInstance({ ip: 'fe80::1c2e:f014:10d8:50f5' });
+            const model2 = new ModelInstance({ ip: '1.1.1' });
+
+            const valid = model.validate();
+            const valid2 = model2.validate();
+
+            expect(valid.success).equal(false);
+            expect(valid2.success).equal(false);
         });
 
         it('--> is HexColor', () => {


### PR DESCRIPTION
# What does this PR do:
- Changes the `lib/model.js` to support both the simple validation case:

```js
{
  // ...
  validate: 'isEmail',
  // ...
}
```

and a more complex case where you need to pass more arguments to the validation function:
```js
{
  // ... ,
  validate: {
    rule: 'isIP',
    args: [4],
  }
}
```

This way, there's no breaking change (old API is still supported).

Should fix issue #38.

# Where should the reviewer start:
  - Check the [changes](https://github.com/sebelga/gstore-node/pull/40/files).
  - Also check the docs to see if everything is as it should (proper section and clear explanation).
  - Have into consideration that this only solves the need to pass multiple arguments to a validation function.

# Unit tests:
 - Adds two new test cases to the `test/model-test.js`:
   - '--> is IP ok'
   - '--> is IP ko'