### PR TITLE
Adds support for validation of embedded entities via custom functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,22 @@ const bscrypt = require('bcrypt-nodejs');
 const Schema = gstore.Schema;
 
 /**
+ * A custom validation function for an embedded entity
+ */
+const validateAccessList = (value, validator) => {
+    if (!Array.isArray(value)) {
+        return false;
+    }
+
+    return value.some((item) => {
+        const isValidIp = !validator.isEmpty(item.ip) && validator.isIP(item.ip, 4);
+        const isValidHostname = !validator.isEmpty(item.hostname);
+        
+        return isValidHostname && isValidIp;
+    });
+}
+
+/**
  * Create the schema for the User Model
 */
 const userSchema = new Schema({
@@ -85,9 +101,8 @@ const userSchema = new Schema({
     dateOfBirth: { type: 'datetime' },
     bio: { type: 'string', excludeFromIndexes: true },
     website: { validate: 'isURL', optional: true },
-    ip: {
-        validate: 'isIP',
-        args: [4]
+    accessList: {
+        validate: validateAccessList,
     },
 });
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -1061,6 +1061,7 @@ class Model extends Entity {
                  */
                 let validationArgs = [propertyValue];
                 let validationRule = schema.paths[k].validate;
+                let validationFn = null;
 
                 /**
                  * If the validate property is an object, then it's assumed that
@@ -1071,11 +1072,20 @@ class Model extends Entity {
                  */
                 if (typeof validationRule === 'object') {
                     validationRule = schema.paths[k].validate.rule;
+
+                    if (typeof validationRule === 'function') {
+                        validationFn = validationRule;
+                        validationArgs.push(validator);
+                    } else {
+                        validationFn = validator[validationRule];
+                    }
+
                     validationArgs = validationArgs.concat(schema.paths[k].validate.args || []);
+                } else {
+                    validationFn = validator[validationRule];
                 }
 
-                /** Then it gets easier to use 'apply' on both simple and complex cases */
-                if (!validator[validationRule].apply(validator, validationArgs)) {
+                if (!validationFn.apply(validator, validationArgs)) {
                     errors[k] = new GstoreError.ValidatorError({
                         message: `Wrong format for property { ${k} }`,
                     });


### PR DESCRIPTION
# What does this PR do:

As proposed in my comment on the issue #41 ( https://github.com/sebelga/gstore-node/issues/41#issuecomment-271517435 ), this PR adds the possibility to pass custom functions as 'rules' on the validate.

The function then receives the validator as context, but also as 2nd argument (being the 1st the value). Why? Because _fat arrow functions_ are not bindable, that's why! 😄 

# Where should the reviewer start:
  - Diffs on `lib/model.js` and the `test/model-test.js`