### PR TITLE
Adds missing comma to the example's schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ const userSchema = new Schema({
             validate: 'isIP',
             args: [4],
         }
-     }
+    },
     accessList: {
         validate: {
             rule: validateAccessList,


### PR DESCRIPTION
# What does this PR do:

Adds missing comma on the UserSchema's example. Typo created by me when I added the `accessList` definition after the `ip` property.

# Where should the reviewer start:
  - Diffs.