### PR TITLE
feat(hooks): Model.delete() "post" hooks callback scope

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -870,7 +870,7 @@ class Model extends Entity {
      * @param {String} hook The name of the hook (save, delete...)
      * @param {Array} args The arguments passed to the original method
      */
-    static __scopeHook(hook, args) {
+    static __scopeHook(hook, args, hookName, hookType) {
         const _this = this;
 
         switch (hook) {
@@ -893,18 +893,29 @@ class Model extends Entity {
                 arrify(args[0].__override)[0] :
                 args[0];
 
-            const multiple = is.array(id);
-            id = parseId(id);
+            if (is.array(id)) {
+                return null;
+            }
 
-            const ancestors = args.length > 1 ? args[1] : undefined;
-            const namespace = args.length > 2 ? args[2] : undefined;
-            const key = args.length > 4 ? args[4] : undefined;
+            id = parseId(id);
+            let ancestors;
+            let namespace;
+            let key;
+
+            if (hookType === 'post') {
+                ({ key } = args);
+                if (is.array(key)) {
+                    return null;
+                }
+            } else {
+                ([ancestors, namespace,,, key] = args);
+            }
 
             if (!id && !ancestors && !namespace && !key) {
                 return undefined;
             }
 
-            return multiple ? null : _this.__model(null, id, ancestors, namespace, key);
+            return _this.__model(null, id, ancestors, namespace, key);
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "is": "^3.2.1",
     "moment": "^2.21.0",
     "optional": "^0.1.4",
-    "promised-hooks": "^3.0.0",
+    "promised-hooks": "^3.1.0",
     "validator": "^9.4.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "scripts": {
     "commit": "git-cz",
-    "coverage-old": "istanbul cover ./node_modules/mocha/bin/_mocha -- -R spec --recursive",
     "coverage": "nyc mocha test --recursive",
     "coveralls": "nyc mocha test --recursive && nyc report --reporter=text-lcov | coveralls && rm -rf ./coverage",
     "local-datastore": "gcloud beta emulators datastore start --data-dir=$PWD/local-datastore",
@@ -52,7 +51,7 @@
       "text"
     ]
   },
-  "license": "ISC",
+  "license": "MIT",
   "config": {
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"

--- a/test/model-test.js
+++ b/test/model-test.js
@@ -852,14 +852,15 @@ describe('Model', () => {
             });
         });
 
-        it('should set "pre" hook scope to entity being deleted (1)', () => {
+        it('should set "pre" hook scope to entity being deleted (1)', (done) => {
             schema.pre('delete', function preDelete() {
-                expect(this.className).equal('Entity');
+                expect(this instanceof Entity);
+                done();
                 return Promise.resolve();
             });
             ModelInstance = Model.compile('Blog', schema, gstore);
 
-            return ModelInstance.delete(123);
+            ModelInstance.delete(123);
         });
 
         it('should set "pre" hook scope to entity being deleted (2)', () => {
@@ -896,10 +897,12 @@ describe('Model', () => {
             });
         });
 
-        it('should pass key deleted to post hooks', () => {
-            schema.post('delete', (response) => {
-                expect(response.key.constructor.name).equal('Key');
-                expect(response.key.id).equal(123);
+        it('should pass key deleted to post hooks and set the scope to the entity deleted', () => {
+            schema.post('delete', function postDeleteHook({ key }) {
+                expect(key.constructor.name).equal('Key');
+                expect(key.id).equal(123);
+                expect(this instanceof Entity);
+                expect(this.entityKey).equal(key);
                 return Promise.resolve();
             });
             ModelInstance = Model.compile('Blog', schema, gstore);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4080,9 +4080,9 @@ progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
-promised-hooks@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/promised-hooks/-/promised-hooks-3.0.0.tgz#855e43ade1da99ea7ec3c822f855d134127c05a5"
+promised-hooks@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/promised-hooks/-/promised-hooks-3.1.0.tgz#a50915c222cc2a302a44ee07ae35d18453b2e9c1"
   dependencies:
     arrify "^1.0.1"
     is "^3.2.0"


### PR DESCRIPTION
The scope (this) inside a "post" Model.delete() hook is now correctly set to the entity that has
just been deleted. The callback still receives the key deleted in its first argument.