### PR TITLE
fix(queries): Forward options object to Datastore Query

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -40,7 +40,7 @@ class Query {
                     .then(onQuery).catch(onError);
             }
 
-            return this.__originalRun.call(query).then(onQuery).catch(onError);
+            return this.__originalRun.call(query, options).then(onQuery).catch(onError);
 
             // -----------------------------------------------
 
@@ -165,6 +165,9 @@ class Query {
     }
 
     findAround(property, value, options, namespace, cb) {
+        // TODO!! Add namespace inside options object (consistency!)
+        // + update the DOC!
+
         const Model = this.Model || this;
         const args = Array.prototype.slice.apply(arguments);
         cb = args.pop();

--- a/test/integration/data.js
+++ b/test/integration/data.js
@@ -8,10 +8,16 @@ const k1 = ds.key(['Parent', 'default', 'User', 111]);
 const k2 = ds.key(['Parent', 'default', 'User', 222]);
 const k3 = ds.key(['Blog', 'default', 'Post', 111]);
 const k4 = ds.key(['Blog', 'default', 'Post', 222]);
+
 const user1 = { name: 'john', age: 20 };
 const user2 = { name: 'mick', age: 20 };
 const post1 = { title: 'Hello', category: 'tech' };
 const post2 = { title: 'World', category: 'tech' };
+
+const entity1 = { key: k1, data: user1 };
+const entity2 = { key: k2, data: user2 };
+const entity3 = { key: k3, data: post1 };
+const entity4 = { key: k4, data: post2 };
 
 const query = ds
     .createQuery('User')
@@ -32,6 +38,10 @@ module.exports = {
     user2,
     post1,
     post2,
+    entity1,
+    entity2,
+    entity3,
+    entity4,
     query,
     query2,
 };

--- a/test/integration/query.integration-test.js
+++ b/test/integration/query.integration-test.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const Datastore = require('@google-cloud/datastore');
+const chai = require('chai');
+const { argv } = require('yargs');
+const gstore = require('../../lib')();
+
+const { Schema } = gstore;
+
+const ds = new Datastore({ projectId: 'gstore-integration-tests' });
+gstore.connect(ds);
+
+const { expect } = chai;
+const {
+    k1, k2, k3, k4, entity1, entity2, entity3, entity4,
+} = require('./data');
+
+const allKeys = [k1, k2, k3, k4];
+
+const cleanUp = (cb) => {
+    ds.delete(allKeys).then(cb);
+};
+
+describe('Integration Tests (Queries)', () => {
+    let Model;
+    let query;
+
+    before(function integrationTest(done) {
+        if (argv.int !== true) {
+            this.skip();
+        }
+        gstore.models = {};
+        gstore.modelSchemas = {};
+
+        const schema = new Schema({});
+        Model = gstore.model('User', schema);
+        query = Model.query();
+
+        Model.deleteAll()
+            .then(() => (
+                // Add a few entities in the Datastore
+                ds.save([entity1, entity2, entity3, entity4])
+                    .then(() => done())
+            ));
+    });
+
+    beforeEach(function beforeEachIntTest() {
+        if (argv.int !== true) {
+            this.skip();
+        }
+    });
+
+    after(function afterAllIntTest(done) {
+        if (argv.int !== true) {
+            this.skip();
+        }
+        cleanUp(() => done());
+    });
+
+    it('should forward options to underlying Datastore.Query', () => (
+        query.run({ consistency: 'strong' })
+            .then(({ entities }) => {
+                expect(entities.length).equal(2);
+            })
+    ));
+});

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -157,16 +157,25 @@ describe('Query', () => {
         ));
 
         it('should accept "readAll" option', () => (
-            query.run(({ readAll: true }))
+            query.run({ readAll: true })
                 .then((response) => {
                     assert.isDefined(response.entities[0].password);
                 })
         ));
 
         it('should accept "showKey" option', () => (
-            query.run(({ showKey: true }))
+            query.run({ showKey: true })
                 .then((response) => {
                     assert.isDefined(response.entities[0].__key);
+                })
+        ));
+
+        it('should forward options to underlying Datastore.Query', () => (
+            query.run({ consistency: 'strong' })
+                .then(() => {
+                    assert(query.__originalRun.called);
+                    const { args } = query.__originalRun.getCall(0);
+                    expect(args[0].consistency).equal('strong');
                 })
         ));
 


### PR DESCRIPTION
The query.run() "options" configuration was not forwarded to the underlying Query instance. This
means that the { consistency: 'strong' } was not taken into account. Now the options is correctly
forwared and the "consistency" setting passed.