### PR TITLE
feat(gstore-save): Add save method to global save

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -132,7 +132,7 @@ class Gstore {
         }
 
         // Convert gstore entities to datastore forma ({key, data})
-        args[0] = datastoreSerializer.entitiesToDatastore(entities);
+        args[0] = datastoreSerializer.entitiesToDatastore(entities, options);
 
         if (args[1] && args[1].constructor && args[1].constructor.name === 'Transaction') {
             // Save inside a transaction

--- a/lib/serializers/datastore.js
+++ b/lib/serializers/datastore.js
@@ -3,7 +3,7 @@
 const is = require('is');
 const arrify = require('arrify');
 
-function toDatastore(entity) {
+function toDatastore(entity, options = {}) {
     const excludeFromIndexes = [...entity.excludeFromIndexes] || [];
 
     let isArray;
@@ -57,12 +57,14 @@ function toDatastore(entity) {
         datastoreFormat.excludeFromIndexes = excludeFromIndexes;
     }
 
+    if (options.method) {
+        datastoreFormat.method = options.method;
+    }
+
     return datastoreFormat;
 }
 
-function fromDatastore(entity, options) {
-    options = options || {};
-
+function fromDatastore(entity, options = {}) {
     switch (options.format) {
         case 'ENTITY':
             return convertToEntity.call(this);
@@ -122,7 +124,7 @@ function fromDatastore(entity, options) {
  * @param {any} entities Entity(ies) to format
  * @returns {array} the formated entity(ies)
  */
-function entitiesToDatastore(entities) {
+function entitiesToDatastore(entities, options) {
     const multiple = is.array(entities);
     entities = arrify(entities);
 
@@ -131,7 +133,7 @@ function entitiesToDatastore(entities) {
         return entities;
     }
 
-    const result = entities.map(toDatastore);
+    const result = entities.map(e => toDatastore(e, options));
 
     return multiple ? result : result[0];
 }

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -189,10 +189,10 @@ describe('gstore-node', () => {
         ));
 
         it('should convert entity instances to datastore Format', () => {
-            const model1 = new ModelInstance({ name: 'John' });
-            const model2 = new ModelInstance({ name: 'Mick' });
+            const entity1 = new ModelInstance({ name: 'John' });
+            const entity2 = new ModelInstance({ name: 'Mick' });
 
-            return gstore.save([model1, model2]).then(() => {
+            return gstore.save([entity1, entity2]).then(() => {
                 const { args } = ds.save.getCall(0);
                 const firstEntity = args[0][0];
                 assert.isUndefined(firstEntity.className);
@@ -201,9 +201,9 @@ describe('gstore-node', () => {
         });
 
         it('should work inside a transaction', () => {
-            const model1 = new ModelInstance({ name: 'John' });
+            const entity = new ModelInstance({ name: 'John' });
 
-            gstore.save(model1, transaction);
+            gstore.save(entity, transaction);
 
             expect(transaction.save.called).equal(true);
             expect(ds.save.called).equal(false);
@@ -214,9 +214,9 @@ describe('gstore-node', () => {
 
             sinon.stub(ds, 'save').callsFake((entity, cb) => cb());
 
-            const model = new ModelInstance({ name: 'John' });
+            const entity = new ModelInstance({ name: 'John' });
 
-            return gstore.save(model, () => {
+            return gstore.save(entity, () => {
                 const { args } = ds.save.getCall(0);
                 const firstEntity = args[0];
                 assert.isUndefined(firstEntity.className);
@@ -245,6 +245,16 @@ describe('gstore-node', () => {
                     expect(entity1.validate.called).equal(true);
                     expect(entity3.validate.called).equal(false); // fail fast, exit validation
                     done();
+                });
+        });
+
+        it('should allow to pass a save method ("insert", "update", "upsert")', () => {
+            const entity = new ModelInstance({ name: 'John' });
+
+            return gstore.save(entity, undefined, { method: 'insert' })
+                .then(() => {
+                    const { args } = ds.save.getCall(0);
+                    expect(args[0].method).equal('insert');
                 });
         });
     });


### PR DESCRIPTION
gstore.save() method has accepts a options object to declare the save method (insert, update,
upsert)

#105