### PR TITLE
Changed the type definition to match with @google-cloud/datastore

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -754,9 +754,9 @@ declare namespace GstoreNode {
      */
     start?: string;
     /**
-     * @type {string}
+     * @type {number}
      */
-    offset?: string;
+    offset?: number;
   }
 
   interface Validation {


### PR DESCRIPTION
Offset is a number in the official Google node module so I just changed the type definition to match up with https://cloud.google.com/nodejs/docs/reference/datastore/2.0.x/Query#offset