### PR TITLE
refactor: Change gstore instantiation to be consistent with es modules

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for [gstore-node] [1.1.0]
+// Type definitions for gstore-node v5.0.0
 // Project: [gstore-node]
 // Definitions by: [Sébastien Loix] <[http://s.loix.me]>
 
@@ -9,850 +9,846 @@ import { entity } from '@google-cloud/datastore/build/src/entity';
 import { Query as GoogleDatastoreQuery, Operator } from '@google-cloud/datastore/build/src/query';
 import { Transaction } from '@google-cloud/datastore/build/src/transaction';
 
-export default GstoreNode;
+/**
+ * gstore-node Instance
+ *
+ * @class Gstore
+ */
+declare class Gstore {
+constructor(config?:  GstoreConfig);
 
-declare function GstoreNode(config?: GstoreNode.GstoreConfig): GstoreNode.Gstore;
+/**
+ * The unerlying google-cloud Datastore instance
+ */
+ds: any;
 
-declare namespace GstoreNode {
-  /**
-   * gstore-node Instance
-   *
-   * @class Gstore
-   */
-  class Gstore {
-    constructor();
+/**
+ * The underlying gstore-cache instance
+ *
+ * @type {GstoreCache}
+ */
+cache: GstoreCache.Cache;
 
+Schema: typeof Schema;
+
+/**
+ * Default Values helpers for Schemas
+ *
+ * @type {{ NOW: string }}
+ */
+defaultValues: { NOW: string };
+
+errors: {
+    codes: ErrorCodes;
+    GstoreError: typeof GstoreError;
+    ValidationError: typeof ValidationError;
+    TypeError: typeof TypeError;
+    ValueError: typeof ValueError;
+};
+
+/**
+ * Initialize a @google-cloud/datastore Transaction
+ */
+transaction(): any;
+
+/**
+ * Connect gstore node to the Datastore instance
+ *
+ * @param {Datastore} datastore A Datastore instance
+ */
+connect(datastore: Datastore): void;
+
+/**
+ * Initalize a gstore-node Model
+ *
+ * @param {string} entityKind The Google Entity Kind
+ * @returns {Model} A gstore Model
+ */
+model<T = { [propName: string]: any }>(entityKind: string, schema?: Schema<T>): Model<T>;
+
+/**
+ * Create a DataLoader instance
+ *
+ * @returns {DataLoader} The DataLoader instance
+ * @link https://sebelga.gitbooks.io/gstore-node/content/dataloader.html#dataloader
+ */
+createDataLoader(): DataLoader;
+
+/**
+ * This method is an alias of the underlying @google-cloud/datastore save() method, with the exception that you can pass it an Entity instance or an Array of entities instances and this method will first convert the instances to the correct Datastore format before saving.
+ *
+ * @param {(Entity | Entity[])} entity The entity(ies) to delete (any Entity Kind). Can be one or many (Array).
+ * @param {Transaction} [transaction] An Optional transaction to save the entities into
+ * @returns {Promise<any>}
+ */
+save(entity: Entity | Entity[], transaction?: Transaction, options?: { validate?: boolean, method?: 'insert' | 'update' | 'upsert' }): Promise<any>;
+}
+
+/**
+ * gstore-node Schema
+ *
+ * @class Schema
+ */
+declare class Schema<T = SchemaPath> {
+constructor(properties: { [P in keyof T]: SchemaPathDefinition }, options?: SchemaOptions);
+
+/**
+ * Custom Schema Types
+ */
+static Types: {
+    Double: 'double';
+    GeoPoint: 'geoPoint';
+    Key: 'key';
+};
+
+/**
+ * Schema paths
+ *
+ * @type {{ [propName: string]: SchemaPathDefinition }}
+ */
+readonly paths: { [P in keyof T]: SchemaPathDefinition };
+/**
+ * Add custom methods to entities.
+ * @link https://sebelga.gitbooks.io/gstore-node/content/schema/custom-methods.html
+ *
+ * @example
+ * ```
+ * schema.methods.profilePict = function() {
+     return this.model('Image').get(this.imgIdx)
+    * }
+    * ```
+    */
+readonly methods: { [propName: string]: () => any };
+
+/**
+ * Getter / Setter for Schema paths.
+ *
+ * @param {string} propName The entity property
+ * @param {SchemaPathDefinition} [definition] The property definition
+ * @link https://sebelga.gitbooks.io/gstore-node/content/schema/schema-methods/path.html
+ */
+path(propName: string, definition?: SchemaPathDefinition): void;
+
+/**
+ * Getter / Setter of a virtual property.
+ * Virtual properties are created dynamically and not saved in the Datastore.
+ *
+ * @param {string} propName The virtual property name
+ * @link https://sebelga.gitbooks.io/gstore-node/content/schema/schema-methods/virtual.html
+ */
+virtual(
+    propName: string
+): {
+    get(cb: () => any): void;
+    set(cb: (propName: string) => void): void;
+};
+
+queries(shortcutQuery: 'list', options: QueryListOptions): void;
+
+/**
+ * Register a middleware to be executed before "save()", "delete()", "findOne()" or any of your custom method. The callback will receive the original argument(s) passed to the target method. You can modify them in your resolve passing an object with an __override property containing the new parameter(s) for the target method.
+ *
+ * @param {string} method The target method to add the hook to
+ * @param {(...args: any[]) => Promise<any>} callback Function to execute before the target method. It must return a Promise
+ * @link https://sebelga.gitbooks.io/gstore-node/content/middleware-hooks/pre-hooks.html
+ */
+pre(method: string, callback: funcReturningPromise | funcReturningPromise[]): void;
+
+/**
+ * Register a "post" middelware to execute after a target method.
+ *
+ * @param {string} method The target method to add the hook to
+ * @param {(response: any) => Promise<any>} callback Function to execute after the target method. It must return a Promise
+ * @link https://sebelga.gitbooks.io/gstore-node/content/middleware-hooks/post-hooks.html
+ */
+post(method: string, callback: funcReturningPromise | funcReturningPromise[]): void;
+}
+
+interface Model<T = { [propName: string]: any }> {
+/**
+ * gstore-node instance
+ *
+ * @static
+ * @type {Gstore}
+ */
+gstore: Gstore;
+
+/**
+ * The Model Schema
+ *
+ * @static
+ * @type {Schema}
+ */
+schema: Schema;
+
+/**
+ * The Model Datastore Entity Kind
+ *
+ * @static
+ * @type {string}
+ */
+entityKind: string;
+
+/**
+ * Creates an entity, instance of the Model.
+ * @param {{ [propName: string]: any }} data The entity data
+ * @param {(string | number)} [id] An optional entity id or name. If not provided it will be automatically generated.
+ * @param {(Array<string | number>)} [ancestors] The entity Ancestors
+ * @param {string} [namespace] The entity Namespace
+ */
+new (
+    data: { [P in keyof T]: T[P] },
+    id?: string | number,
+    ancestors?: Array<string | number>,
+    namespace?: string
+): Entity<T>;
+
+/**
+ * Fetch an Entity by KEY from the Datastore
+ *
+ * @param {(string | number | string[] | number[])} id The entity ID
+ * @param {(Array<string | number>)} [ancestors] The entity Ancestors
+ * @param {string} [namespace] The entity Namespace
+ * @param {*} [transaction] The current Datastore Transaction (if any)
+ * @param {({ preserveOrder: boolean, dataloader: any, cache: boolean, ttl: number | { [propName: string] : number } })} [options] Additional configuration
+ * @returns {Promise<any>} The entity fetched from the Datastore
+ * @link https://sebelga.gitbooks.io/gstore-node/content/model/get.html
+ */
+get<U extends string | number | Array<string | number>>(
+    id: U,
+    ancestors?: Array<string | number>,
+    namespace?: string,
+    transaction?: Transaction,
+    options?: {
     /**
-     * The unerlying google-cloud Datastore instance
-     */
-    ds: any;
-
-    /**
-     * The underlying gstore-cache instance
+     * If you have provided an Array of ids, the order returned by the Datastore is not guaranteed. If you need the entities back in the same order of the IDs provided, then set `preserveOrder: true`
      *
-     * @type {GstoreCache}
+     * @type {boolean}
+     * @default false
      */
-    cache: GstoreCache.Cache;
-
-    Schema: typeof Schema;
-
+    preserveOrder?: boolean;
     /**
-     * Default Values helpers for Schemas
+     * An optional Dataloader instance.
      *
-     * @type {{ NOW: string }}
-     */
-    defaultValues: { NOW: string };
-
-    errors: {
-      codes: ErrorCodes;
-      GstoreError: typeof GstoreError;
-      ValidationError: typeof ValidationError;
-      TypeError: typeof TypeError;
-      ValueError: typeof ValueError;
-    };
-
-    /**
-     * Initialize a @google-cloud/datastore Transaction
-     */
-    transaction(): any;
-
-    /**
-     * Connect gstore node to the Datastore instance
-     *
-     * @param {Datastore} datastore A Datastore instance
-     */
-    connect(datastore: Datastore): void;
-
-    /**
-     * Initalize a gstore-node Model
-     *
-     * @param {string} entityKind The Google Entity Kind
-     * @returns {Model} A gstore Model
-     */
-    model<T = { [propName: string]: any }>(entityKind: string, schema?: Schema<T>): Model<T>;
-
-    /**
-     * Create a DataLoader instance
-     *
-     * @returns {DataLoader} The DataLoader instance
+     * @type {*}
      * @link https://sebelga.gitbooks.io/gstore-node/content/dataloader.html#dataloader
      */
-    createDataLoader(): DataLoader;
-
+    dataloader?: any;
     /**
-     * This method is an alias of the underlying @google-cloud/datastore save() method, with the exception that you can pass it an Entity instance or an Array of entities instances and this method will first convert the instances to the correct Datastore format before saving.
+     * Only if the cache has been activated.
+     * Fetch the entity from the cache first. If you want to bypass the cache and go to the Datastore directly, set `cache: false`.
      *
-     * @param {(Entity | Entity[])} entity The entity(ies) to delete (any Entity Kind). Can be one or many (Array).
-     * @param {Transaction} [transaction] An Optional transaction to save the entities into
-     * @returns {Promise<any>}
+     * @type {boolean}
+     * @default The "global" cache configuration
+     * @link https://sebelga.gitbooks.io/gstore-node/content/cache.html
      */
-    save(entity: Entity | Entity[], transaction?: Transaction, options?: { validate?: boolean, method?: 'insert' | 'update' | 'upsert' }): Promise<any>;
-  }
-
-  /**
-   * gstore-node Schema
-   *
-   * @class Schema
-   */
-  class Schema<T = SchemaPath> {
-    constructor(properties: { [P in keyof T]: SchemaPathDefinition }, options?: SchemaOptions);
-
+    cache?: boolean;
     /**
-     * Custom Schema Types
-     */
-    static Types: {
-      Double: 'double';
-      GeoPoint: 'geoPoint';
-      Key: 'key';
-    };
-
-    /**
-     * Schema paths
+     * Only if the cache has been activated.
+     * After the entty has been fetched from the Datastore it will be added to the cache. You can specify here a custom ttl (Time To Live) for the entity.
      *
-     * @type {{ [propName: string]: SchemaPathDefinition }}
+     * @type {(number | { [propName: string] : number })}
+     * @default The "ttl.keys" cache configuration
+     * @link https://sebelga.gitbooks.io/gstore-node/content/cache.html
      */
-    readonly paths: { [P in keyof T]: SchemaPathDefinition };
-    /**
-     * Add custom methods to entities.
-     * @link https://sebelga.gitbooks.io/gstore-node/content/schema/custom-methods.html
-     *
-     * @example
-     * ```
-     * schema.methods.profilePict = function() {
-         return this.model('Image').get(this.imgIdx)
-     * }
-     * ```
-     */
-    readonly methods: { [propName: string]: () => any };
-
-    /**
-     * Getter / Setter for Schema paths.
-     *
-     * @param {string} propName The entity property
-     * @param {SchemaPathDefinition} [definition] The property definition
-     * @link https://sebelga.gitbooks.io/gstore-node/content/schema/schema-methods/path.html
-     */
-    path(propName: string, definition?: SchemaPathDefinition): void;
-
-    /**
-     * Getter / Setter of a virtual property.
-     * Virtual properties are created dynamically and not saved in the Datastore.
-     *
-     * @param {string} propName The virtual property name
-     * @link https://sebelga.gitbooks.io/gstore-node/content/schema/schema-methods/virtual.html
-     */
-    virtual(
-      propName: string
-    ): {
-      get(cb: () => any): void;
-      set(cb: (propName: string) => void): void;
-    };
-
-    queries(shortcutQuery: 'list', options: QueryListOptions): void;
-
-    /**
-     * Register a middleware to be executed before "save()", "delete()", "findOne()" or any of your custom method. The callback will receive the original argument(s) passed to the target method. You can modify them in your resolve passing an object with an __override property containing the new parameter(s) for the target method.
-     *
-     * @param {string} method The target method to add the hook to
-     * @param {(...args: any[]) => Promise<any>} callback Function to execute before the target method. It must return a Promise
-     * @link https://sebelga.gitbooks.io/gstore-node/content/middleware-hooks/pre-hooks.html
-     */
-    pre(method: string, callback: funcReturningPromise | funcReturningPromise[]): void;
-
-    /**
-     * Register a "post" middelware to execute after a target method.
-     *
-     * @param {string} method The target method to add the hook to
-     * @param {(response: any) => Promise<any>} callback Function to execute after the target method. It must return a Promise
-     * @link https://sebelga.gitbooks.io/gstore-node/content/middleware-hooks/post-hooks.html
-     */
-    post(method: string, callback: funcReturningPromise | funcReturningPromise[]): void;
-  }
-
-  interface Model<T = { [propName: string]: any }> {
-    /**
-     * gstore-node instance
-     *
-     * @static
-     * @type {Gstore}
-     */
-    gstore: Gstore;
-
-    /**
-     * The Model Schema
-     *
-     * @static
-     * @type {Schema}
-     */
-    schema: Schema;
-
-    /**
-     * The Model Datastore Entity Kind
-     *
-     * @static
-     * @type {string}
-     */
-    entityKind: string;
-
-    /**
-     * Creates an entity, instance of the Model.
-     * @param {{ [propName: string]: any }} data The entity data
-     * @param {(string | number)} [id] An optional entity id or name. If not provided it will be automatically generated.
-     * @param {(Array<string | number>)} [ancestors] The entity Ancestors
-     * @param {string} [namespace] The entity Namespace
-     */
-    new (
-      data: { [P in keyof T]: T[P] },
-      id?: string | number,
-      ancestors?: Array<string | number>,
-      namespace?: string
-    ): Entity<T>;
-
-    /**
-     * Fetch an Entity by KEY from the Datastore
-     *
-     * @param {(string | number | string[] | number[])} id The entity ID
-     * @param {(Array<string | number>)} [ancestors] The entity Ancestors
-     * @param {string} [namespace] The entity Namespace
-     * @param {*} [transaction] The current Datastore Transaction (if any)
-     * @param {({ preserveOrder: boolean, dataloader: any, cache: boolean, ttl: number | { [propName: string] : number } })} [options] Additional configuration
-     * @returns {Promise<any>} The entity fetched from the Datastore
-     * @link https://sebelga.gitbooks.io/gstore-node/content/model/get.html
-     */
-    get<U extends string | number | Array<string | number>>(
-      id: U,
-      ancestors?: Array<string | number>,
-      namespace?: string,
-      transaction?: Transaction,
-      options?: {
-        /**
-         * If you have provided an Array of ids, the order returned by the Datastore is not guaranteed. If you need the entities back in the same order of the IDs provided, then set `preserveOrder: true`
-         *
-         * @type {boolean}
-         * @default false
-         */
-        preserveOrder?: boolean;
-        /**
-         * An optional Dataloader instance.
-         *
-         * @type {*}
-         * @link https://sebelga.gitbooks.io/gstore-node/content/dataloader.html#dataloader
-         */
-        dataloader?: any;
-        /**
-         * Only if the cache has been activated.
-         * Fetch the entity from the cache first. If you want to bypass the cache and go to the Datastore directly, set `cache: false`.
-         *
-         * @type {boolean}
-         * @default The "global" cache configuration
-         * @link https://sebelga.gitbooks.io/gstore-node/content/cache.html
-         */
-        cache?: boolean;
-        /**
-         * Only if the cache has been activated.
-         * After the entty has been fetched from the Datastore it will be added to the cache. You can specify here a custom ttl (Time To Live) for the entity.
-         *
-         * @type {(number | { [propName: string] : number })}
-         * @default The "ttl.keys" cache configuration
-         * @link https://sebelga.gitbooks.io/gstore-node/content/cache.html
-         */
-        ttl?: number | { [propName: string]: number };
-      }
-    ): PromiseWithPopulate<U extends Array<string | number> ? Entity<T>[] : Entity<T>>;
-
-    /**
-     * Update an Entity in the Datastore
-     *
-     * @static
-     * @param {(string | number)} id Entity id or name
-     * @param {*} data The data to update (it will be merged with the data in the Datastore unless options.replace is set to "true")
-     * @param {(Array<string | number>)} [ancestors] The entity Ancestors
-     * @param {string} [namespace] The entity Namespace
-     * @param {*} [transaction] The current transaction (if any)
-     * @param {{ dataloader?: any, replace?: boolean }} [options] Additional configuration
-     * @returns {Promise<any>} The entity updated in the Datastore
-     * @link https://sebelga.gitbooks.io/gstore-node/content/model/update-method.html
-     */
-    update(
-      id: string | number,
-      data: any,
-      ancestors?: Array<string | number>,
-      namespace?: string,
-      transaction?: Transaction,
-      options?: {
-        /**
-         * An optional Dataloader instance.
-         *
-         * @type {*}
-         * @link https://sebelga.gitbooks.io/gstore-node/content/dataloader.html#dataloader
-         */
-        dataloader?: any;
-
-        /**
-         * By default, gstore-node update en entity in 3 steps (inside a Transaction): fetch the entity in the Datastore, merge the data with the existing entity data and then save the entiy back to the Datastore. If you don't need to merge the data and want to replace whatever is in the Datastore, set `replace: true`.
-         *
-         * @type {boolean}
-         * @default false
-         */
-        replace?: boolean;
-      }
-    ): Promise<Entity<T>>;
-
-    /**
-     * Delete an Entity from the Datastore
-     *
-     * @static
-     * @param {(string | number)} id Entity id or name
-     * @param {(Array<string | number>)} [ancestors] The entity Ancestors
-     * @param {string} [namespace] The entity Namespace
-     * @param {*} [transaction] The current transaction (if any)
-     * @param {(entity.Key | entity.Key[])} [keys] If you already know the Key, you can provide it instead of passing an id/ancestors/namespace. You might then as well just call "gstore.ds.delete(Key)" but then you would not have the "hooks" triggered in case you have added some in your Schema.
-     * @returns {Promise<{ success: boolean, key: entity.Key, apiResponse: any }>}
-     * @link https://sebelga.gitbooks.io/gstore-node/content/model/delete.html
-     */
-    delete(
-      id?: string | number | (number | string)[],
-      ancestors?: Array<string | number>,
-      namespace?: string,
-      transaction?: Transaction,
-      keys?: entity.Key | entity.Key[]
-    ): Promise<DeleteResult>;
-
-    /**
-     * Dynamically remove a property from indexes. If you have set "explicityOnly: false" in your Schema options, then all the properties not declared in the Schema will be included in the indexes. This method allows you to dynamically exclude from indexes certain properties."
-     *
-     * @static
-     * @param {(string | string[])} propName Property name (can be one or an Array of properties)
-     * @link https://sebelga.gitbooks.io/gstore-node/content/model/other-methods.html
-     */
-    excludeFromIndexes(propName: string | string[]): void;
-
-    /**
-     * Generates one or several entity key(s) for the Model.
-     *
-     * @static
-     * @param {(string | number)} id Entity id or name
-     * @param {(Array<string | number>)} [ancestors] The entity Ancestors
-     * @param {string} [namespace] The entity Namespace
-     * @returns {entity.Key}
-     * @link https://sebelga.gitbooks.io/gstore-node/content/model/key.html
-     */
-    key(id: string | number, ancestors?: Array<string | number>, namespace?: string): entity.Key;
-
-    /**
-     * Sanitize the data. It will remove all the properties marked as "write: false" and convert "null" (string) to Null.
-     *
-     * @param {*} data The data to sanitize
-     * @returns {*} The data sanitized
-     * @link https://sebelga.gitbooks.io/gstore-node/content/model/sanitize.html
-     */
-    sanitize(data: { [propName: string]: any }): { [P in keyof T]: T[P] };
-
-    /**
-     * Clear all the Queries from the cache *linked* to the Model Entity Kind. You can also pass one or several keys to delete from the cache.
-     * You normally don't have to call this method as gstore-node does it for you automatically each time you add/edit or delete an entity.
-     *
-     * @static
-     * @param {(entity.Key | entity.Key[])} [keys] Optional entity Keys to remove from the cache with the Queries
-     * @returns {Promise<void>}
-     * @link https://sebelga.gitbooks.io/gstore-node/content/model/clearcache.html
-     */
-    clearCache(keys?: entity.Key | entity.Key[]): Promise<void>;
-
-    /**
-     * Initialize a Datastore Query for the Model's entity Kind
-     *
-     * @static
-     * @param {string} [namespace] Optional namespace for the Query
-     * @param {Transaction} [transaction] Optional Transaction to run the query into
-     * @returns {GoogleDatastoreQuery} A Datastore Query instance
-     * @link https://sebelga.gitbooks.io/gstore-node/content/queries/google-cloud-queries.html
-     */
-    query(namespace?: string, transaction?: Transaction): Query<T>;
-
-    /**
-     * Shortcut for listing entities from a Model. List queries are meant to quickly list entities with predefined settings without having to create Query instances.
-     *
-     * @static
-     * @param {QueryListOptions} [options]
-     * @returns {Promise<any>}
-     * @link https://sebelga.gitbooks.io/gstore-node/content/queries/list.html
-     */
-    list<U extends QueryListOptions>(options?: U): PromiseWithPopulate<QueryResult<T, U>>;
-
-    /**
-     * Quickly find an entity by passing key/value pairs.
-     *
-     * @static
-     * @param {{ [propName: string]: any }} keyValues Key / Values pairs
-     * @param {(Array<string | number>)} [ancestors] Optional Ancestors to add to the Query
-     * @param {string} [namespace] Optional Namespace to run the Query into
-     * @param {({cache?: boolean; ttl?: number | { [propName: string]: number }})} [options] Additional configuration
-     * @example
-     ```
-        UserModel.findOne({ email: 'john[at]snow.com' }).then(...);
-        ```
-     * @returns {Promise<any>}
-     * @link https://sebelga.gitbooks.io/gstore-node/content/queries/findone.html
-     */
-    findOne(
-      keyValues: { [propName: string]: any },
-      ancestors?: Array<string | number>,
-      namespace?: string,
-      options?: {
-        cache?: boolean;
-        ttl?: number | { [propName: string]: number };
-      }
-    ): PromiseWithPopulate<Entity<T>>;
-
-    /**
-     * Delete all the entities of a Model. It queries the entitites by batches of 500 (maximum set by the Datastore) and delete them. It then repeat the operation until no more entities are found.
-     *
-     * @static
-     * @param {(Array<string | number>)} [ancestors] Optional Ancestors to add to the Query
-     * @param {string} [namespace] Optional Namespace to run the Query into
-     * @returns {Promise<{ success: boolean; message: 'string' }>}
-     * @link https://sebelga.gitbooks.io/gstore-node/content/queries/deleteall.html
-     */
-    deleteAll(ancestors?: Array<string | number>, namespace?: string): Promise<{ success: boolean; message: 'string' }>;
-
-    /**
-     * Find entities before or after an entity based on a property and a value.
-     *
-     * @static
-     * @param {string} propName The property to look around
-     * @param {*} value The property value
-     * @param {({ before: number, readAll?:boolean, format?: 'JSON' | 'ENTITY', showKey?: boolean } | { after: number, readAll?:boolean, format?: 'JSON' | 'ENTITY', showKey?: boolean } & QueryOptions)} options Additional configuration
-     * @returns {Promise<any>}
-     * @example
-     ```
-        // Find the next 20 post after March 1st 2018
-        BlogPost.findAround('publishedOn', '2018-03-01', { after: 20 })
-        ```
-     * @link https://sebelga.gitbooks.io/gstore-node/content/queries/findaround.html
-     */
-    findAround<U extends QueryFindAroundOptions>(
-      propName: string,
-      value: any,
-      options: U
-    ): PromiseWithPopulate<{ entities: U["format"] extends EntityFormatType ? Array<Entity<T>> : Array<T> }>;
-  }
-
-  class EntityKlass<T> {
-    /**
-     * gstore-node instance
-     *
-     * @type {Gstore}
-     */
-    gstore: Gstore;
-
-    /**
-     * The Entity Model Schema
-     *
-     * @type {Schema}
-     */
-    schema: Schema;
-
-    /**
-     * The Entity Datastore Entity Kind
-     *
-     * @type {string}
-     */
-    entityKind: string;
-
-    /**
-     * The entity KEY
-     *
-     * @type {entity.Key}
-     */
-    entityKey: entity.Key;
-
-    /**
-     * The entity data
-     *
-     * @type {*}
-     */
-    entityData: { [P in keyof T]: T[P] };
-
-    /**
-     * The entity Key id name or number
-     *
-     * @type {(number | string)}
-     */
-    id: number | string;
-
-    /**
-     * Entity context object to store custom data
-     *
-     * @type {*}
-     */
-    context: any;
-
-    /**
-     * Save the entity in the Datastore
-     *
-     * @param {Transaction} [transaction] The current Transaction (if any)
-     * @param {({ method?: 'upsert' | 'insert' | 'update' })} [options] Additional configuration
-     * @returns {Promise<any>}
-     * @link https://sebelga.gitbooks.io/gstore-node/content/entity/methods/save.html
-     */
-    save(
-      transaction?: Transaction,
-      options?: {
-        /**
-         * The saving method. "upsert" will update the entity *or* create it if it does not exist. "insert" will only save the entity if it *does not* exist. "update" will only save the entity if it *does* exist.
-         *
-         * @type {('upsert' | 'insert' | 'update')}
-         * @default 'upsert'
-         */
-        method?: 'upsert' | 'insert' | 'update';
-      }
-    ): Promise<Entity<T>>;
-
-    /**
-     * Return the entity data object with the entity id.  The properties on the Schema where "read" has been set to "false" won't be included unless you set "readAll" to "true" in the options.
-     *
-     * @param {{ readAll?: boolean, virtuals?: boolean, showKey?: boolean }} options Additional configuration
-     * @returns {*}
-     * @link https://sebelga.gitbooks.io/gstore-node/content/entity/methods/plain.html
-     */
-    plain(options?: {
-      /**
-       * Output all the entity data properties, regardless of the Schema "read" setting
-       *
-       * @type {boolean}
-       * @default false
-       */
-      readAll?: boolean;
-      /**
-       * Add the virtual properties defined on the Schema
-       *
-       * @type {boolean}
-       * @default false
-       */
-      virtuals?: boolean;
-      /**
-       * Add the full entity KEY object in a "__key" property
-       *
-       * @type {boolean}
-       * @default false
-       */
-      showKey?: boolean;
-    }): T & { [propName: string]: any };
-
-    /**
-     * Access a Model from an entity
-     *
-     * @param {string} entityKind The entity Kind
-     * @returns {Model} The Model
-     * @example
-     ```
-        const user = new User({ name: 'john', pictId: 123});
-        const ImageModel = user.model('Image');
-        ImageModel.get(user.pictId).then(...);
-        ```
-      * @link https://sebelga.gitbooks.io/gstore-node/content/entity/methods/model.html
-      */
-    model<T = { [propName: string]: any }>(entityKind: string): Model<T>;
-
-    /**
-     * Fetch the entity data from the Datastore and merge it in the entity.
-     *
-     * @returns {Promise<any>}
-     */
-    datastoreEntity(): Promise<Entity<T>>;
-
-    /**
-     * Validate the entity data. It returns an object with "error" and "value" properties.  If the error is null, it is valid. The value returned is the entityData sanitized (unknown properties removed).
-     *
-     * @returns {({ error: ValidationError, value: any } | Promise<any>)}
-     */
-    validate(): Validation | Promise<any>;
-
-    /**
-     * Populate entity references (whose properties are an entity Key) and merge them on the entity
-     *
-     * @param refs The entity references to fetch from the Datastore. Can be one or multiple (Array)
-     * @param properties The properties to return from the reference entities. If not specified, all properties will be returned
-     */
-    populate<U extends string | string[]>(refs?: U, properties?: U extends Array<string> ? undefined : string | string[]): PromiseWithPopulate<EntityKlass<T>>
-  }
-
-  // -----------------------------------------------------------------------
-  // -- INTERFACES
-  // -----------------------------------------------------------------------
-
-  type EntityFormatType = 'ENTITY';
-  type JSONFormatType = 'JSON';
-
-  type Entity<T = { [propName: string]: any }> = EntityKlass<T> & T;
-
-  type funcReturningPromise = (...args: any[]) => Promise<any>;
-  interface PromiseWithPopulate<T> extends Promise<T> {
-    populate: <U extends string | string[]>(refs?: U, properties?: U extends Array<string> ? undefined : string | string[]) => PromiseWithPopulate<T>
-  }
-
-  interface QueryResult<T, U extends QueryOptions> {
-      entities: U["format"] extends EntityFormatType ? Array<Entity<T>> : Array<T & { id: string | number }>;
-      nextPageCursor?: string;
+    ttl?: number | { [propName: string]: number };
     }
+): PromiseWithPopulate<U extends Array<string | number> ? Entity<T>[] : Entity<T>>;
 
-  type DeleteResult = { key: entity.Key; success?: boolean; apiResponse?: any };
-
-  type PropType =
-    | 'string'
-    | 'int'
-    | 'double'
-    | 'boolean'
-    | 'datetime'
-    | 'array'
-    | 'object'
-    | 'geoPoint'
-    | 'buffer'
-    | NumberConstructor
-    | StringConstructor
-    | ObjectConstructor
-    | ArrayConstructor
-    | BooleanConstructor
-    | DateConstructor
-    | typeof Buffer;
-
-  /**
-   * gstore-node instance configuration
-   *
-   * @interface GstoreConfig
-   */
-  interface GstoreConfig {
-    namespace?: string;
-    cache?: Boolean | CacheConfig;
+/**
+ * Update an Entity in the Datastore
+ *
+ * @static
+ * @param {(string | number)} id Entity id or name
+ * @param {*} data The data to update (it will be merged with the data in the Datastore unless options.replace is set to "true")
+ * @param {(Array<string | number>)} [ancestors] The entity Ancestors
+ * @param {string} [namespace] The entity Namespace
+ * @param {*} [transaction] The current transaction (if any)
+ * @param {{ dataloader?: any, replace?: boolean }} [options] Additional configuration
+ * @returns {Promise<any>} The entity updated in the Datastore
+ * @link https://sebelga.gitbooks.io/gstore-node/content/model/update-method.html
+ */
+update(
+    id: string | number,
+    data: any,
+    ancestors?: Array<string | number>,
+    namespace?: string,
+    transaction?: Transaction,
+    options?: {
     /**
-     * If set to "true" (defaut), when fetching an entity by key and the entity is not found in the Datastore,
-      gstore will throw a "ERR_ENTITY_NOT_FOUND" error. If set to "false", "null" will be returned.
-     */
-    errorOnEntityNotFound?: Boolean;
-  }
-
-  /**
-   * Cache configuration
-   * All the properties are optional.
-   *
-   * @interface CacheConfig
-   */
-  interface CacheConfig {
-    stores?: Array<any>;
-    config?: CacheConfigOptions;
-  }
-
-  interface CacheConfigOptions {
-    ttl: {
-      keys: number;
-      queries: number;
-      memory?: {
-        keys: number;
-        queries: number;
-      };
-      redis?: {
-        keys: number;
-        queries: number;
-      };
-      [key: string]:
-        | {
-            keys: number;
-            queries: number;
-          }
-        | number
-        | void;
-    };
-    cachePrefix?: {
-      keys: string;
-      queries: string;
-    };
-    global?: boolean;
-  }
-
-  interface SchemaPath<T = any> {
-    [propName: string]: SchemaPathDefinition;
-  }
-
-  interface SchemaPathDefinition {
-    type?: PropType;
-    validate?: string | { rule: string | ((...args: any[]) => boolean); args: any[] };
-    optional?: boolean;
-    default?: any;
-    excludeFromIndexes?: boolean | string | string[];
-    read?: boolean;
-    excludeFromRead?: string[];
-    write?: boolean;
-    required?: boolean;
-    joi?: any;
-  }
-
-  interface SchemaOptions {
-    validateBeforeSave?: boolean;
-    explicitOnly?: boolean;
-    queries?: {
-      readAll?: boolean;
-      format?: JSONFormatType | EntityFormatType;
-      showKey?: string;
-    };
-    keyType?: 'id' | 'name' | 'auto';
-    joi?: boolean | { extra?: any; options?: any };
-  }
-
-  interface QueryOptions {
-    /**
-     * Specify either strong or eventual. If not specified, default values are chosen by Datastore for the operation. Learn more about strong and eventual consistency in the link below
+     * An optional Dataloader instance.
      *
-     * @type {('strong' | 'eventual')}
-     * @link https://cloud.google.com/datastore/docs/articles/balancing-strong-and-eventual-consistency-with-google-cloud-datastore
+     * @type {*}
+     * @link https://sebelga.gitbooks.io/gstore-node/content/dataloader.html#dataloader
      */
-    consistency?: 'strong' | 'eventual';
+    dataloader?: any;
+
     /**
-     * If set to true will return all the properties of the entity, regardless of the *read* parameter defined in the Schema
+     * By default, gstore-node update en entity in 3 steps (inside a Transaction): fetch the entity in the Datastore, merge the data with the existing entity data and then save the entiy back to the Datastore. If you don't need to merge the data and want to replace whatever is in the Datastore, set `replace: true`.
+     *
+     * @type {boolean}
+     * @default false
+     */
+    replace?: boolean;
+    }
+): Promise<Entity<T>>;
+
+/**
+ * Delete an Entity from the Datastore
+ *
+ * @static
+ * @param {(string | number)} id Entity id or name
+ * @param {(Array<string | number>)} [ancestors] The entity Ancestors
+ * @param {string} [namespace] The entity Namespace
+ * @param {*} [transaction] The current transaction (if any)
+ * @param {(entity.Key | entity.Key[])} [keys] If you already know the Key, you can provide it instead of passing an id/ancestors/namespace. You might then as well just call "gstore.ds.delete(Key)" but then you would not have the "hooks" triggered in case you have added some in your Schema.
+ * @returns {Promise<{ success: boolean, key: entity.Key, apiResponse: any }>}
+ * @link https://sebelga.gitbooks.io/gstore-node/content/model/delete.html
+ */
+delete(
+    id?: string | number | (number | string)[],
+    ancestors?: Array<string | number>,
+    namespace?: string,
+    transaction?: Transaction,
+    keys?: entity.Key | entity.Key[]
+): Promise<DeleteResult>;
+
+/**
+ * Dynamically remove a property from indexes. If you have set "explicityOnly: false" in your Schema options, then all the properties not declared in the Schema will be included in the indexes. This method allows you to dynamically exclude from indexes certain properties."
+ *
+ * @static
+ * @param {(string | string[])} propName Property name (can be one or an Array of properties)
+ * @link https://sebelga.gitbooks.io/gstore-node/content/model/other-methods.html
+ */
+excludeFromIndexes(propName: string | string[]): void;
+
+/**
+ * Generates one or several entity key(s) for the Model.
+ *
+ * @static
+ * @param {(string | number)} id Entity id or name
+ * @param {(Array<string | number>)} [ancestors] The entity Ancestors
+ * @param {string} [namespace] The entity Namespace
+ * @returns {entity.Key}
+ * @link https://sebelga.gitbooks.io/gstore-node/content/model/key.html
+ */
+key(id: string | number, ancestors?: Array<string | number>, namespace?: string): entity.Key;
+
+/**
+ * Sanitize the data. It will remove all the properties marked as "write: false" and convert "null" (string) to Null.
+ *
+ * @param {*} data The data to sanitize
+ * @returns {*} The data sanitized
+ * @link https://sebelga.gitbooks.io/gstore-node/content/model/sanitize.html
+ */
+sanitize(data: { [propName: string]: any }): { [P in keyof T]: T[P] };
+
+/**
+ * Clear all the Queries from the cache *linked* to the Model Entity Kind. You can also pass one or several keys to delete from the cache.
+ * You normally don't have to call this method as gstore-node does it for you automatically each time you add/edit or delete an entity.
+ *
+ * @static
+ * @param {(entity.Key | entity.Key[])} [keys] Optional entity Keys to remove from the cache with the Queries
+ * @returns {Promise<void>}
+ * @link https://sebelga.gitbooks.io/gstore-node/content/model/clearcache.html
+ */
+clearCache(keys?: entity.Key | entity.Key[]): Promise<void>;
+
+/**
+ * Initialize a Datastore Query for the Model's entity Kind
+ *
+ * @static
+ * @param {string} [namespace] Optional namespace for the Query
+ * @param {Transaction} [transaction] Optional Transaction to run the query into
+ * @returns {GoogleDatastoreQuery} A Datastore Query instance
+ * @link https://sebelga.gitbooks.io/gstore-node/content/queries/google-cloud-queries.html
+ */
+query(namespace?: string, transaction?: Transaction): Query<T>;
+
+/**
+ * Shortcut for listing entities from a Model. List queries are meant to quickly list entities with predefined settings without having to create Query instances.
+ *
+ * @static
+ * @param {QueryListOptions} [options]
+ * @returns {Promise<any>}
+ * @link https://sebelga.gitbooks.io/gstore-node/content/queries/list.html
+ */
+list<U extends QueryListOptions>(options?: U): PromiseWithPopulate<QueryResult<T, U>>;
+
+/**
+ * Quickly find an entity by passing key/value pairs.
+ *
+ * @static
+ * @param {{ [propName: string]: any }} keyValues Key / Values pairs
+ * @param {(Array<string | number>)} [ancestors] Optional Ancestors to add to the Query
+ * @param {string} [namespace] Optional Namespace to run the Query into
+ * @param {({cache?: boolean; ttl?: number | { [propName: string]: number }})} [options] Additional configuration
+ * @example
+ ```
+    UserModel.findOne({ email: 'john[at]snow.com' }).then(...);
+    ```
+    * @returns {Promise<any>}
+    * @link https://sebelga.gitbooks.io/gstore-node/content/queries/findone.html
+    */
+findOne(
+    keyValues: { [propName: string]: any },
+    ancestors?: Array<string | number>,
+    namespace?: string,
+    options?: {
+    cache?: boolean;
+    ttl?: number | { [propName: string]: number };
+    }
+): PromiseWithPopulate<Entity<T>>;
+
+/**
+ * Delete all the entities of a Model. It queries the entitites by batches of 500 (maximum set by the Datastore) and delete them. It then repeat the operation until no more entities are found.
+ *
+ * @static
+ * @param {(Array<string | number>)} [ancestors] Optional Ancestors to add to the Query
+ * @param {string} [namespace] Optional Namespace to run the Query into
+ * @returns {Promise<{ success: boolean; message: 'string' }>}
+ * @link https://sebelga.gitbooks.io/gstore-node/content/queries/deleteall.html
+ */
+deleteAll(ancestors?: Array<string | number>, namespace?: string): Promise<{ success: boolean; message: 'string' }>;
+
+/**
+ * Find entities before or after an entity based on a property and a value.
+ *
+ * @static
+ * @param {string} propName The property to look around
+ * @param {*} value The property value
+ * @param {({ before: number, readAll?:boolean, format?: 'JSON' | 'ENTITY', showKey?: boolean } | { after: number, readAll?:boolean, format?: 'JSON' | 'ENTITY', showKey?: boolean } & QueryOptions)} options Additional configuration
+ * @returns {Promise<any>}
+ * @example
+ ```
+    // Find the next 20 post after March 1st 2018
+    BlogPost.findAround('publishedOn', '2018-03-01', { after: 20 })
+    ```
+    * @link https://sebelga.gitbooks.io/gstore-node/content/queries/findaround.html
+    */
+findAround<U extends QueryFindAroundOptions>(
+    propName: string,
+    value: any,
+    options: U
+): PromiseWithPopulate<{ entities: U["format"] extends EntityFormatType ? Array<Entity<T>> : Array<T> }>;
+}
+
+declare class EntityKlass<T> {
+/**
+ * gstore-node instance
+ *
+ * @type {Gstore}
+ */
+gstore: Gstore;
+
+/**
+ * The Entity Model Schema
+ *
+ * @type {Schema}
+ */
+schema: Schema;
+
+/**
+ * The Entity Datastore Entity Kind
+ *
+ * @type {string}
+ */
+entityKind: string;
+
+/**
+ * The entity KEY
+ *
+ * @type {entity.Key}
+ */
+entityKey: entity.Key;
+
+/**
+ * The entity data
+ *
+ * @type {*}
+ */
+entityData: { [P in keyof T]: T[P] };
+
+/**
+ * The entity Key id name or number
+ *
+ * @type {(number | string)}
+ */
+id: number | string;
+
+/**
+ * Entity context object to store custom data
+ *
+ * @type {*}
+ */
+context: any;
+
+/**
+ * Save the entity in the Datastore
+ *
+ * @param {Transaction} [transaction] The current Transaction (if any)
+ * @param {({ method?: 'upsert' | 'insert' | 'update' })} [options] Additional configuration
+ * @returns {Promise<any>}
+ * @link https://sebelga.gitbooks.io/gstore-node/content/entity/methods/save.html
+ */
+save(
+    transaction?: Transaction,
+    options?: {
+    /**
+     * The saving method. "upsert" will update the entity *or* create it if it does not exist. "insert" will only save the entity if it *does not* exist. "update" will only save the entity if it *does* exist.
+     *
+     * @type {('upsert' | 'insert' | 'update')}
+     * @default 'upsert'
+     */
+    method?: 'upsert' | 'insert' | 'update';
+    }
+): Promise<Entity<T>>;
+
+/**
+ * Return the entity data object with the entity id.  The properties on the Schema where "read" has been set to "false" won't be included unless you set "readAll" to "true" in the options.
+ *
+ * @param {{ readAll?: boolean, virtuals?: boolean, showKey?: boolean }} options Additional configuration
+ * @returns {*}
+ * @link https://sebelga.gitbooks.io/gstore-node/content/entity/methods/plain.html
+ */
+plain(options?: {
+    /**
+     * Output all the entity data properties, regardless of the Schema "read" setting
      *
      * @type {boolean}
      * @default false
      */
     readAll?: boolean;
     /**
-     * Response format for the entities. Either plain object or entity instances
+     * Add the virtual properties defined on the Schema
      *
-     * @type {string}
-     * @default 'JSON'
+     * @type {boolean}
+     * @default false
      */
-    format?: JSONFormatType | EntityFormatType;
+    virtuals?: boolean;
     /**
-     * Add a "__key" property to the entity data with the complete Key from the Datastore.
+     * Add the full entity KEY object in a "__key" property
      *
      * @type {boolean}
      * @default false
      */
     showKey?: boolean;
-    /**
-     * If set to true, it will read from the cache and prime the cache with the response of the query.
-     *
-     * @type {boolean}
-     * @default The "global" cache configuration.
-     */
-    cache?: boolean;
-    /**
-     * Custom TTL value for the cache. For multi-store it can be an object of ttl values
-     *
-     * @type {(number | { [propName: string]: number })}
-     * @default The cache.ttl.queries value
-     */
-    ttl?: number | { [propName: string]: number };
-  }
+}): T & { [propName: string]: any };
 
-  interface QueryListOptions extends QueryOptions{
-    /**
-     * Optional namespace for the Query
-     *
-     * @type {string}
-     */
-    namespace?: string;
-    /**
-     * @type {number}
-     */
-    limit?: number;
-    /**
-     * Descending is optional and default to "false"
-     *
-     * @example ```{ property: 'userName', descending: true }```
-     * @type {({ property: 'string', descending?: boolean } | { property: 'string', descending?: boolean }[])}
-     */
-    order?: { property: string; descending?: boolean } | { property: string; descending?: boolean }[];
-    /**
-     * @type {(string | string[])}
-     */
-    select?: string | string[];
-    /**
-     * @type {([string, any] | [string, string, any] | (any)[][])}
-     */
-    filters?: [string, any] | [string, Operator, any] | (any)[][];
-    /**
-     * @type {Array<any>}
-     */
-    ancestors?: Array<string | number>;
-    /**
-     * @type {string}
-     */
-    start?: string;
-    /**
-     * @type {number}
-     */
-    offset?: number;
-  }
+/**
+ * Access a Model from an entity
+ *
+ * @param {string} entityKind The entity Kind
+ * @returns {Model} The Model
+ * @example
+ ```
+    const user = new User({ name: 'john', pictId: 123});
+    const ImageModel = user.model('Image');
+    ImageModel.get(user.pictId).then(...);
+    ```
+    * @link https://sebelga.gitbooks.io/gstore-node/content/entity/methods/model.html
+    */
+model<T = { [propName: string]: any }>(entityKind: string): Model<T>;
 
-  interface QueryFindAroundOptions extends QueryOptions {
-    before?: number;
-    after?: number;
+/**
+ * Fetch the entity data from the Datastore and merge it in the entity.
+ *
+ * @returns {Promise<any>}
+ */
+datastoreEntity(): Promise<Entity<T>>;
+
+/**
+ * Validate the entity data. It returns an object with "error" and "value" properties.  If the error is null, it is valid. The value returned is the entityData sanitized (unknown properties removed).
+ *
+ * @returns {({ error: ValidationError, value: any } | Promise<any>)}
+ */
+validate(): Validation | Promise<any>;
+
+/**
+ * Populate entity references (whose properties are an entity Key) and merge them on the entity
+ *
+ * @param refs The entity references to fetch from the Datastore. Can be one or multiple (Array)
+ * @param properties The properties to return from the reference entities. If not specified, all properties will be returned
+ */
+populate<U extends string | string[]>(refs?: U, properties?: U extends Array<string> ? undefined : string | string[]): PromiseWithPopulate<EntityKlass<T>>
+}
+
+// -----------------------------------------------------------------------
+// -- INTERFACES
+// -----------------------------------------------------------------------
+
+type EntityFormatType = 'ENTITY';
+type JSONFormatType = 'JSON';
+
+type Entity<T = { [propName: string]: any }> = EntityKlass<T> & T;
+
+type funcReturningPromise = (...args: any[]) => Promise<any>;
+interface PromiseWithPopulate<T> extends Promise<T> {
+populate: <U extends string | string[]>(refs?: U, properties?: U extends Array<string> ? undefined : string | string[]) => PromiseWithPopulate<T>;
+}
+
+interface QueryResult<T, U extends QueryOptions> {
+    entities: U["format"] extends EntityFormatType ? Array<Entity<T>> : Array<T & { id: string | number }>;
+    nextPageCursor?: string;
+}
+
+type DeleteResult = { key: entity.Key; success?: boolean; apiResponse?: any };
+
+type PropType =
+| 'string'
+| 'int'
+| 'double'
+| 'boolean'
+| 'datetime'
+| 'array'
+| 'object'
+| 'geoPoint'
+| 'buffer'
+| NumberConstructor
+| StringConstructor
+| ObjectConstructor
+| ArrayConstructor
+| BooleanConstructor
+| DateConstructor
+| typeof Buffer;
+
+/**
+ * gstore-node instance configuration
+ *
+ * @interface GstoreConfig
+ */
+interface GstoreConfig {
+namespace?: string;
+cache?: Boolean | CacheConfig;
+/**
+ * If set to "true" (defaut), when fetching an entity by key and the entity is not found in the Datastore,
+     gstore will throw a "ERR_ENTITY_NOT_FOUND" error. If set to "false", "null" will be returned.
+    */
+errorOnEntityNotFound?: Boolean;
+}
+
+/**
+ * Cache configuration
+ * All the properties are optional.
+ *
+ * @interface CacheConfig
+ */
+interface CacheConfig {
+stores?: Array<any>;
+config?: CacheConfigOptions;
+}
+
+interface CacheConfigOptions {
+ttl: {
+    keys: number;
+    queries: number;
+    memory?: {
+    keys: number;
+    queries: number;
+    };
+    redis?: {
+    keys: number;
+    queries: number;
+    };
+    [key: string]:
+    | {
+        keys: number;
+        queries: number;
+        }
+    | number
+    | void;
+};
+cachePrefix?: {
+    keys: string;
+    queries: string;
+};
+global?: boolean;
+}
+
+interface SchemaPath<T = any> {
+[propName: string]: SchemaPathDefinition;
+}
+
+interface SchemaPathDefinition {
+type?: PropType;
+validate?: string | { rule: string | ((...args: any[]) => boolean); args: any[] };
+optional?: boolean;
+default?: any;
+excludeFromIndexes?: boolean | string | string[];
+read?: boolean;
+excludeFromRead?: string[];
+write?: boolean;
+required?: boolean;
+joi?: any;
+}
+
+interface SchemaOptions {
+validateBeforeSave?: boolean;
+explicitOnly?: boolean;
+queries?: {
     readAll?: boolean;
     format?: JSONFormatType | EntityFormatType;
-    showKey?: boolean
-  }
-
-  interface Validation {
-    error: ValidationError;
-    value: any;
-  }
-
-  class GstoreError extends Error {
-    name: string;
-    message: string;
-    stack: string;
-    code: keyof ErrorCodes;
-  }
-
-  class ValidationError extends GstoreError {}
-
-  class TypeError extends GstoreError {}
-
-  class ValueError extends GstoreError {}
-
-  interface ErrorCodes {
-    ERR_ENTITY_NOT_FOUND: 'ERR_ENTITY_NOT_FOUND';
-    ERR_GENERIC: 'ERR_GENERIC';
-    ERR_VALIDATION: 'ERR_VALIDATION';
-    ERR_PROP_TYPE: 'ERR_PROP_TYPE';
-    ERR_PROP_VALUE: 'ERR_PROP_VALUE';
-    ERR_PROP_NOT_ALLOWED: 'ERR_PROP_NOT_ALLOWED';
-    ERR_PROP_REQUIRED: 'ERR_PROP_REQUIRED';
-    ERR_PROP_IN_RANGE: 'ERR_PROP_IN_RANGE';
-  }
-
-  type FunctionPropertiesNames<T> = { [K in keyof T]: T[K] extends Function ? K : never }[keyof T];
-  type FunctionProperties<T> = Pick<T, FunctionPropertiesNames<T>>;
-
-  interface GoogleDatastoreQueryMethods<T> {
-    filter(property: string, operator: Operator, value: any): Query<T>;
-    filter(property: string, value: any): Query<T>;
-
-    hasAncestor(key: entity.Key): Query<T>;
-
-    order(property: string, options?: { descending: boolean; }): Query<T>;
-
-    groupBy(properties: string | ReadonlyArray<string>): Query<T>;
-
-    select(properties: string | ReadonlyArray<string>): Query<T>;
-
-    start(cursorToken: string): Query<T>;
-
-    end(cursorToken: string): Query<T>;
-
-    limit(n: number): Query<T>;
-
-    offset(n: number): Query<T>;
-
-    runStream(): NodeJS.ReadableStream;
-  }
-
-  interface Query<T> extends GoogleDatastoreQueryMethods<T>{
-    run<U extends QueryOptions>( options?: U ): PromiseWithPopulate<QueryResult<T, U>>;
-  }
-
-  interface DataLoader {}
+    showKey?: string;
+};
+keyType?: 'id' | 'name' | 'auto';
+joi?: boolean | { extra?: any; options?: any };
 }
+
+interface QueryOptions {
+/**
+ * Specify either strong or eventual. If not specified, default values are chosen by Datastore for the operation. Learn more about strong and eventual consistency in the link below
+ *
+ * @type {('strong' | 'eventual')}
+ * @link https://cloud.google.com/datastore/docs/articles/balancing-strong-and-eventual-consistency-with-google-cloud-datastore
+ */
+consistency?: 'strong' | 'eventual';
+/**
+ * If set to true will return all the properties of the entity, regardless of the *read* parameter defined in the Schema
+ *
+ * @type {boolean}
+ * @default false
+ */
+readAll?: boolean;
+/**
+ * Response format for the entities. Either plain object or entity instances
+ *
+ * @type {string}
+ * @default 'JSON'
+ */
+format?: JSONFormatType | EntityFormatType;
+/**
+ * Add a "__key" property to the entity data with the complete Key from the Datastore.
+ *
+ * @type {boolean}
+ * @default false
+ */
+showKey?: boolean;
+/**
+ * If set to true, it will read from the cache and prime the cache with the response of the query.
+ *
+ * @type {boolean}
+ * @default The "global" cache configuration.
+ */
+cache?: boolean;
+/**
+ * Custom TTL value for the cache. For multi-store it can be an object of ttl values
+ *
+ * @type {(number | { [propName: string]: number })}
+ * @default The cache.ttl.queries value
+ */
+ttl?: number | { [propName: string]: number };
+}
+
+interface QueryListOptions extends QueryOptions{
+/**
+ * Optional namespace for the Query
+ *
+ * @type {string}
+ */
+namespace?: string;
+/**
+ * @type {number}
+ */
+limit?: number;
+/**
+ * Descending is optional and default to "false"
+ *
+ * @example ```{ property: 'userName', descending: true }```
+ * @type {({ property: 'string', descending?: boolean } | { property: 'string', descending?: boolean }[])}
+ */
+order?: { property: string; descending?: boolean } | { property: string; descending?: boolean }[];
+/**
+ * @type {(string | string[])}
+ */
+select?: string | string[];
+/**
+ * @type {([string, any] | [string, string, any] | (any)[][])}
+ */
+filters?: [string, any] | [string, Operator, any] | (any)[][];
+/**
+ * @type {Array<any>}
+ */
+ancestors?: Array<string | number>;
+/**
+ * @type {string}
+ */
+start?: string;
+/**
+ * @type {number}
+ */
+offset?: number;
+}
+
+interface QueryFindAroundOptions extends QueryOptions {
+before?: number;
+after?: number;
+readAll?: boolean;
+format?: JSONFormatType | EntityFormatType;
+showKey?: boolean
+}
+
+interface Validation {
+error: ValidationError;
+value: any;
+}
+
+declare class GstoreError extends Error {
+name: string;
+message: string;
+stack: string;
+code: keyof ErrorCodes;
+}
+
+declare class ValidationError extends GstoreError {}
+
+declare class TypeError extends GstoreError {}
+
+declare class ValueError extends GstoreError {}
+
+interface ErrorCodes {
+ERR_ENTITY_NOT_FOUND: 'ERR_ENTITY_NOT_FOUND';
+ERR_GENERIC: 'ERR_GENERIC';
+ERR_VALIDATION: 'ERR_VALIDATION';
+ERR_PROP_TYPE: 'ERR_PROP_TYPE';
+ERR_PROP_VALUE: 'ERR_PROP_VALUE';
+ERR_PROP_NOT_ALLOWED: 'ERR_PROP_NOT_ALLOWED';
+ERR_PROP_REQUIRED: 'ERR_PROP_REQUIRED';
+ERR_PROP_IN_RANGE: 'ERR_PROP_IN_RANGE';
+}
+
+type FunctionPropertiesNames<T> = { [K in keyof T]: T[K] extends Function ? K : never }[keyof T];
+type FunctionProperties<T> = Pick<T, FunctionPropertiesNames<T>>;
+
+interface GoogleDatastoreQueryMethods<T> {
+filter(property: string, operator: Operator, value: any): Query<T>;
+filter(property: string, value: any): Query<T>;
+
+hasAncestor(key: entity.Key): Query<T>;
+
+order(property: string, options?: { descending: boolean; }): Query<T>;
+
+groupBy(properties: string | ReadonlyArray<string>): Query<T>;
+
+select(properties: string | ReadonlyArray<string>): Query<T>;
+
+start(cursorToken: string): Query<T>;
+
+end(cursorToken: string): Query<T>;
+
+limit(n: number): Query<T>;
+
+offset(n: number): Query<T>;
+
+runStream(): NodeJS.ReadableStream;
+}
+
+interface Query<T> extends GoogleDatastoreQueryMethods<T>{
+run<U extends QueryOptions>( options?: U ): PromiseWithPopulate<QueryResult<T, U>>;
+}
+
+interface DataLoader {}
+
+export { Gstore, Schema, Entity, Model, Query, GstoreConfig, CacheConfigOptions, Validation }
 
 declare namespace GstoreCache {
   /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,9 +24,6 @@ const { createDataLoader } = require('./dataloader');
 
 const pkg = require('../package.json');
 
-let gstoreInstances = {};
-const gstoreDefaultNamespace = 'gstore-node';
-
 const defaultConfig = {
     cache: undefined,
     errorOnEntityNotFound: true,
@@ -34,6 +31,10 @@ const defaultConfig = {
 
 class Gstore {
     constructor(config = {}) {
+        if (!is.object(config)) {
+            throw new Error('Gstore config must be an object.');
+        }
+
         this.models = {};
         this.modelSchemas = {};
         this.options = {};
@@ -185,33 +186,17 @@ class Gstore {
     }
 }
 
-/**
- * Create a new gstore-node instance
- * @param {*} config gstore-node configuraion
- * @returns {Gstore} A gstore-node instance
- */
-const instanceManager = (config = {}) => {
-    if (!is.undef(config) && !is.object(config)) {
-        throw new Error('Wrong config format for gstore');
-    }
-
-    const { namespace } = config;
-    delete config.namespace;
-    const _namespace = namespace || gstoreDefaultNamespace;
-
-    if ({}.hasOwnProperty.call(gstoreInstances, _namespace)) {
-        return gstoreInstances[_namespace];
-    }
-
-    const gstore = new Gstore(config);
-
-    gstoreInstances[_namespace] = gstore;
-
-    return gstore;
+const instances = {
+    refs: new Map(),
+    get(id) {
+        return this.refs.get(id);
+    },
+    set(id, instance) {
+        this.refs.set(id, instance);
+    },
 };
 
-instanceManager.clear = () => {
-    gstoreInstances = {};
+module.exports = {
+    Gstore,
+    instances,
 };
-
-module.exports = instanceManager;

--- a/test/dataloader-test.js
+++ b/test/dataloader-test.js
@@ -4,8 +4,10 @@ const { Datastore } = require('@google-cloud/datastore');
 const chai = require('chai');
 const sinon = require('sinon');
 
-const gstore = require('../lib/index')();
+const { Gstore } = require('../lib');
 const { createDataLoader } = require('../lib/dataloader');
+
+const gstore = new Gstore();
 
 const { expect, assert } = chai;
 const ds = new Datastore();

--- a/test/entity-test.js
+++ b/test/entity-test.js
@@ -9,10 +9,12 @@ const ds = new Datastore({
     namespace: 'com.mydomain',
     apiEndpoint: 'http://localhost:8080',
 });
+const { Gstore } = require('../lib');
 const datastoreSerializer = require('../lib/serializer').Datastore;
-const gstore = require('../lib')({ namespace: 'entity-no-cache' });
-const gstoreWithCache = require('../')({ namespace: 'entity-with-cache', cache: { config: { ttl: { keys: 600 } } } });
-const { Schema } = require('../lib')();
+
+const gstore = new Gstore();
+const gstoreWithCache = new Gstore({ cache: { config: { ttl: { keys: 600 } } } });
+const { Schema } = gstore;
 
 const { expect, assert } = chai;
 

--- a/test/helpers/validation-test.js
+++ b/test/helpers/validation-test.js
@@ -3,14 +3,13 @@
 const chai = require('chai');
 const Joi = require('joi');
 
+const Schema = require('../../lib/schema');
 const gstoreErrors = require('../../lib/errors');
 const { validation } = require('../../lib/helpers');
 
 const ds = require('../mocks/datastore')({
     namespace: 'com.mydomain',
 });
-
-const { Schema } = require('../../lib')();
 
 const { expect, assert } = chai;
 const { errorCodes } = gstoreErrors;

--- a/test/integration/cache.js
+++ b/test/integration/cache.js
@@ -7,7 +7,7 @@ const chai = require('chai');
 const { Datastore } = require('@google-cloud/datastore');
 const { argv } = require('yargs');
 
-const Gstore = require('../../lib');
+const { Gstore } = require('../../lib');
 
 const ds = new Datastore({ projectId: 'gstore-integration-tests' });
 
@@ -37,8 +37,7 @@ describe('Integration Tests (Cache)', () => {
             this.skip();
         }
         if (!gstore) {
-            gstore = Gstore({
-                namespace: 'gstore-with-redis-cache',
+            gstore = new Gstore({
                 cache: {
                     stores: [{
                         store: redisStore,

--- a/test/integration/entity.js
+++ b/test/integration/entity.js
@@ -4,9 +4,10 @@ const chai = require('chai');
 const Chance = require('chance');
 const { Datastore } = require('@google-cloud/datastore');
 const { argv } = require('yargs');
-const gstore = require('../../lib')({ namespace: 'integration-tests' });
+const { Gstore } = require('../../lib');
 
 const ds = new Datastore({ projectId: 'gstore-integration-tests' });
+const gstore = new Gstore();
 gstore.connect(ds);
 
 const { Schema } = gstore;

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -4,8 +4,9 @@ const chai = require('chai');
 const Chance = require('chance');
 const { Datastore } = require('@google-cloud/datastore');
 const { argv } = require('yargs');
-const gstore = require('../../lib')({ namespace: 'integration-tests' });
+const { Gstore } = require('../../lib');
 
+const gstore = new Gstore();
 const ds = new Datastore({ projectId: 'gstore-integration-tests' });
 gstore.connect(ds);
 

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -9,9 +9,10 @@ const Joi = require('joi');
 const { Datastore } = require('@google-cloud/datastore');
 const { argv } = require('yargs');
 
-const gstore = require('../../lib')({ namespace: 'integration-tests' });
+const { Gstore } = require('../../lib');
 const Entity = require('../../lib/entity');
 
+const gstore = new Gstore();
 const chance = new Chance();
 
 const ds = new Datastore({ projectId: 'gstore-integration-testsx' });

--- a/test/integration/query.js
+++ b/test/integration/query.js
@@ -4,12 +4,10 @@ const chai = require('chai');
 const Chance = require('chance');
 const { argv } = require('yargs');
 const { Datastore } = require('@google-cloud/datastore');
-const gstore = require('../../lib')({ namespace: 'integration-tests' });
-const gstoreWithCache = require('../../lib')({
-    namespace: 'integration-tests-cahe',
-    cache: { config: { ttl: { queries: 600 } } },
-});
+const { Gstore } = require('../../lib');
 
+const gstore = new Gstore();
+const gstoreWithCache = new Gstore({ cache: { config: { ttl: { queries: 600 } } } });
 const ds = new Datastore({ projectId: 'gstore-integration-tests' });
 gstore.connect(ds);
 gstoreWithCache.connect(ds);

--- a/test/integration/schema.js
+++ b/test/integration/schema.js
@@ -6,8 +6,9 @@ const chai = require('chai');
 const Chance = require('chance');
 const { Datastore } = require('@google-cloud/datastore');
 const { argv } = require('yargs');
-const gstore = require('../../lib')({ namespace: 'integration-tests' });
+const { Gstore } = require('../../lib');
 
+const gstore = new Gstore();
 const chance = new Chance();
 const ds = new Datastore({ projectId: 'gstore-integration-tests' });
 gstore.connect(ds);
@@ -30,7 +31,6 @@ describe('Schema (Integration Tests)', () => {
         const schema = new Schema({
             email: {
                 type: String,
-                validate: 'isEmail',
                 required: true,
             },
             password: {
@@ -55,7 +55,7 @@ describe('Schema (Integration Tests)', () => {
         const User = gstore.model('ModelTestsSchema-User', schema);
 
         const email = chance.email();
-        const password = chance.string();
+        const password = chance.string({ length: 10 });
         const user = new User({ email, password });
 
         return user.save().then((entity) => {
@@ -66,6 +66,8 @@ describe('Schema (Integration Tests)', () => {
             const response2 = entity.plain({ readAll: true });
             expect(response2.password).equal(password);
             expect(response2.state).equal('requested');
+        }).catch((err) => {
+            throw (err);
         });
     });
 });

--- a/test/model-test.js
+++ b/test/model-test.js
@@ -6,8 +6,7 @@ const sinon = require('sinon');
 const is = require('is');
 const Joi = require('joi');
 
-const gstore = require('../')();
-const gstoreWithCache = require('../')({ namespace: 'model-with-cache', cache: { config: { ttl: { queries: 600 } } } });
+const { Gstore } = require('../lib');
 const Entity = require('../lib/entity');
 const Model = require('../lib/model');
 const gstoreErrors = require('../lib/errors');
@@ -18,6 +17,8 @@ const Transaction = require('./mocks/transaction');
 const { generateEntities } = require('./mocks/entities');
 const Query = require('./mocks/query');
 
+const gstore = new Gstore();
+const gstoreWithCache = new Gstore({ cache: { config: { ttl: { queries: 600 } } } });
 const { expect, assert } = chai;
 const { Schema, createDataLoader } = gstore;
 

--- a/test/query-test.js
+++ b/test/query-test.js
@@ -3,8 +3,7 @@
 const chai = require('chai');
 const sinon = require('sinon');
 
-const gstore = require('../')();
-const gstoreWithCache = require('../')({ namespace: 'model-with-cache', cache: true });
+const { Gstore } = require('../');
 const ds = require('./mocks/datastore')({
     namespace: 'com.mydomain',
 });
@@ -14,6 +13,8 @@ const { generateEntities } = require('./mocks/entities');
 const { queryHelpers } = require('../lib/helpers');
 const Model = require('../lib/model');
 
+const gstore = new Gstore();
+const gstoreWithCache = new Gstore({ cache: true });
 const { Schema } = gstore;
 const { expect, assert } = chai;
 

--- a/test/schema-test.js
+++ b/test/schema-test.js
@@ -3,8 +3,12 @@
 const chai = require('chai');
 const Joi = require('joi');
 
-const gstore = require('../')();
-const { Schema } = require('../lib')();
+const { Gstore } = require('../lib');
+const ds = require('./mocks/datastore')();
+
+const gstore = new Gstore();
+const { Schema } = gstore;
+gstore.connect(ds);
 
 const { expect, assert } = chai;
 

--- a/test/serializers/datastore-test.js
+++ b/test/serializers/datastore-test.js
@@ -2,13 +2,15 @@
 
 const chai = require('chai');
 const Joi = require('joi');
+
+const { Gstore } = require('../../lib');
 const ds = require('../mocks/datastore')({
     namespace: 'com.mydomain',
 });
-
-const gstore = require('../../lib')();
-const { Schema } = require('../../lib')();
 const datastoreSerializer = require('../../lib/serializer').Datastore;
+
+const gstore = new Gstore();
+const { Schema } = gstore;
 
 const { expect, assert } = chai;
 gstore.connect(ds);


### PR DESCRIPTION

BREAKING CHANGE: The new way to create gstore instances is with "new Gstore(<config>)". Refer to the documentation.