### PR TITLE
fix(model.get()): handle null when entity does not exist

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -152,7 +152,7 @@ class Model extends Entity {
         function onEntity(data) {
             data = arrify(data);
 
-            if (data.length === 0 || typeof data[0] === 'undefined') {
+            if (data.length === 0 || typeof data[0] === 'undefined' || data[0] === null) {
                 if (_this.gstore.config.errorOnEntityNotFound) {
                     return Promise.reject(new GstoreError(
                         errorCodes.ERR_ENTITY_NOT_FOUND,


### PR DESCRIPTION
I was getting the same error described in #26, except with `null` instead of `undefined`:

```
Cannot read property 'Symbol(KEY)' of null
```

Adding `|| data[0] === null` to the `if` condition fixed the issue for me 🙂