### PR TITLE
fix(Model.update()): fix onUpdateError throwing empty object instead of error

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -319,7 +319,7 @@ class Model extends Entity {
             if (internalTransaction) {
                 // If we created the Transaction instance internally for the update, we rollback it
                 // otherwise we leave the rollback() call to the transaction creator
-                return transaction.rollback().then(onTransactionError);
+                return transaction.rollback().then(() => onTransactionError([err]));
             }
 
             return onTransactionError([err]);


### PR DESCRIPTION
Before this PR, if e.g. (joi) validation failed for the data, the error thrown there was lost and instead an empty object `{}` was thrown (this is the default parameter for `onTransactionError`).