### PR TITLE
fix(Model.get()): Consistently return an Array

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -136,7 +136,6 @@ class Model extends Entity {
         ids = ids.map(parseId);
 
         const key = this.key(ids, ancestors, namespace);
-        const isMultiple = Array.isArray(id) && key.length > 1;
         const refsToPopulate = [];
         const { dataloader } = options;
 
@@ -158,12 +157,12 @@ class Model extends Entity {
         function onEntity(entityDataFetched) {
             const entityData = arrify(entityDataFetched);
 
-            if (!isMultiple
+            if (ids.length === 1
                 && (entityData.length === 0 || typeof entityData[0] === 'undefined' || entityData[0] === null)) {
                 if (_this.gstore.config.errorOnEntityNotFound) {
                     return Promise.reject(new GstoreError(
                         errorCodes.ERR_ENTITY_NOT_FOUND,
-                        `${_this.entityKind} { ${id.toString()} } not found`
+                        `${_this.entityKind} { ${ids[0].toString()} } not found`
                     ));
                 }
 
@@ -178,11 +177,13 @@ class Model extends Entity {
                     return _this.__model(data, null, null, null, data[_this.gstore.ds.KEY]);
                 });
 
-            if (isMultiple && options.preserveOrder && entity.every(e => typeof e !== 'undefined' && e !== null)) {
+            if (Array.isArray(id)
+              && options.preserveOrder
+              && entity.every(e => typeof e !== 'undefined' && e !== null)) {
                 entity.sort((a, b) => id.indexOf(a.entityKey.id) - id.indexOf(b.entityKey.id));
             }
 
-            return isMultiple ? entity : entity[0];
+            return Array.isArray(id) ? entity : entity[0];
         }
     }
 

--- a/test/model-test.js
+++ b/test/model-test.js
@@ -330,18 +330,20 @@ describe('Model', () => {
 
             sinon.stub(ds, 'get').resolves([[entity2, entity1]]); // not sorted
 
-            return GstoreModel.get([22, 69], null, null, null, { preserveOrder: true }).then(onResult, onError);
-
-            function onResult(_entity) {
-                expect(is.array(ds.get.getCall(0).args[0])).equal(true);
-                expect(is.array(_entity)).equal(true);
-                expect(_entity[0].entityKey.id).equal(22); // sorted
-            }
-
-            function onError(err) {
-                throw (err);
-            }
+            return GstoreModel
+                .get([22, 69], null, null, null, { preserveOrder: true })
+                .then((_entity) => {
+                    expect(is.array(ds.get.getCall(0).args[0])).equal(true);
+                    expect(is.array(_entity)).equal(true);
+                    expect(_entity[0].entityKey.id).equal(22); // sorted
+                });
         });
+
+        it('should consistently return an array when providing id as an Array', () => GstoreModel
+            .get(['abc'])
+            .then((_entity) => {
+                assert.isTrue(is.array(_entity));
+            }));
 
         it('converting a string integer to real integer', () => GstoreModel.get('123').then(() => {
             assert.isUndefined(ds.get.getCall(0).args[0].name);


### PR DESCRIPTION
When an Array of ids is provided to Model.get(), gstore will now consistently return
an Array. In earlier versions, if an array of 1 id was provided, gstore would return a single entity
instead of an array containing the entity.

This is a BREAKING CHANGE and will create a new major version of gstore.

Fixes #134 