### PR TITLE
Added type for Schema.Types.Key

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -656,6 +656,7 @@ type PropType =
     | "object"
     | "geoPoint"
     | "buffer"
+    | "key"
     | NumberConstructor
     | StringConstructor
     | ObjectConstructor

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -114,7 +114,7 @@ declare class Schema<T = SchemaPath> {
     static Types: {
         Double: "double";
         GeoPoint: "geoPoint";
-        Key: "key";
+        Key: "entityKey";
     };
 
     /**
@@ -656,7 +656,7 @@ type PropType =
     | "object"
     | "geoPoint"
     | "buffer"
-    | "key"
+    | "entityKey"
     | NumberConstructor
     | StringConstructor
     | ObjectConstructor


### PR DESCRIPTION
It looks to me like the PropType relating to Schema.Types.Key is missing.