### PR TITLE
Fix/validate joi default options

### DIFF
--- a/lib/entity.js
+++ b/lib/entity.js
@@ -372,13 +372,13 @@ function parseId(self, id) {
 
 function buildEntityData(self, data) {
     const { schema } = self;
-    const isJoiSchema = !is.undef(schema._joi);
+    const isJoiSchema = schema.isJoi;
 
     let entityData;
 
     // If Joi schema, get its default values
     if (isJoiSchema) {
-        const { error, value } = schema._joi.validate(data);
+        const { error, value } = schema.validateJoi(data);
 
         if (!error) {
             entityData = Object.assign({}, value);

--- a/lib/helpers/validation.js
+++ b/lib/helpers/validation.js
@@ -192,15 +192,10 @@ const validate = (entityData, schema, entityKind, datastore) => {
 
     const props = Object.keys(entityData);
     const totalProps = Object.keys(entityData).length;
-    const isJoi = !is.undef(schema._joi);
 
-    if (isJoi) {
+    if (schema.isJoi) {
         // We leave the validation to Joi
-        const joiOptions = schema.options.joi.options || {};
-        joiOptions.stripUnknown = {}.hasOwnProperty.call(joiOptions, 'stripUnknown')
-            ? joiOptions.stripUnknown
-            : schema.options.explicitOnly !== false;
-        return schema._joi.validate(entityData, joiOptions);
+        return schema.validateJoi(entityData);
     }
 
     for (let i = 0; i < totalProps; i += 1) {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -196,7 +196,7 @@ export class Schema<T = SchemaPath> {
     /**
      * Checks if the schema has a joi config object.
      */
-    get isJoi(): boolean;
+    readonly isJoi: boolean;
 }
 
 export interface Model<T = { [propName: string]: any }> {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -184,6 +184,19 @@ export class Schema<T = SchemaPath> {
         method: string,
         callback: funcReturningPromise | funcReturningPromise[]
     ): void;
+
+    /**
+     * Executes joi.validate on given data. If schema does not have a joi config object data is returned
+     * 
+     * @param {*} data The data to sanitize
+     * @returns {*} The data sanitized
+     */
+    validateJoi(data: { [propName: string]: any }): Validation<{ [P in keyof T]: T[P] }>;
+
+    /**
+     * Checks if the schema has a joi config object.
+     */
+    get isJoi(): boolean;
 }
 
 export interface Model<T = { [propName: string]: any }> {
@@ -844,9 +857,9 @@ export interface QueryFindAroundOptions extends QueryOptions {
     showKey?: boolean;
 }
 
-export interface Validation {
+export interface Validation<T = any> {
     error: ValidationError;
-    value: any;
+    value: T;
 }
 
 declare class GstoreError extends Error {

--- a/lib/model.js
+++ b/lib/model.js
@@ -644,20 +644,24 @@ class Model extends Entity {
             return null;
         }
 
-        const isJoiSchema = !is.undef(schema._joi);
+        const isJoiSchema = schema.isJoi;
 
         let sanitized;
         let joiOptions;
         if (isJoiSchema) {
-            sanitized = schema._joi.validate(data).value;
+            const { error, value } = schema.validateJoi(data);
+            if (!error) {
+                sanitized = Object.assign({}, value);
+            }
             joiOptions = schema.options.joi.options || {};
-        } else {
+        }
+        if (sanitized === undefined) {
             sanitized = Object.assign({}, data);
         }
 
         const isSchemaExplicitOnly = isJoiSchema
-            ? !joiOptions.allowUnknown
-            : schema.options.explicitOnly !== false;
+            ? joiOptions.stripUnknown || !joiOptions.allowUnknown
+            : schema.options.explicitOnly === true;
 
         const isWriteDisabled = options.disabled.includes('write');
         const hasSchemaRefProps = Boolean(schema.__meta.refProps);

--- a/lib/model.js
+++ b/lib/model.js
@@ -660,7 +660,7 @@ class Model extends Entity {
         }
 
         const isSchemaExplicitOnly = isJoiSchema
-            ? joiOptions.stripUnknown || !joiOptions.allowUnknown
+            ? joiOptions.stripUnknown
             : schema.options.explicitOnly === true;
 
         const isWriteDisabled = options.disabled.includes('write');

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -215,9 +215,9 @@ function defaultOptions(options) {
             },
         };
         if (is.object(options.joi)) {
-            options.joi = extend(true, joiOptionsDefault, options.joi);
+            options.joi = extend(true, {}, joiOptionsDefault, options.joi);
         } else {
-            options.joi = joiOptionsDefault;
+            options.joi = Object.assign({}, joiOptionsDefault);
         }
         if (!Object.prototype.hasOwnProperty.call(options.joi.options, 'stripUnknown')) {
             options.joi.options.stripUnknown = options.joi.options.allowUnknown !== true;

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -90,7 +90,7 @@ class Schema {
         // });
 
         if (options) {
-            this._joi = buildJoiSchema(properties, options.joi);
+            this._joi = buildJoiSchema(properties, this.options.joi);
         }
     }
 
@@ -165,7 +165,7 @@ class Schema {
         }
         return this.virtuals[propName];
     }
-}
+        }
 
 /**
  * Static properties
@@ -183,21 +183,37 @@ Schema.Types = {
 function defaultOptions(options) {
     const optionsDefault = {
         validateBeforeSave: true,
+        explicitOnly: true,
         queries: {
             readAll: false,
             format: queries.formats.JSON,
         },
     };
     options = extend(true, {}, optionsDefault, options);
+    if (options.joi) {
+        const joiOptionsDefault = {
+            options: {
+                allowUnknown: options.explicitOnly !== true,
+            },
+        };
+        if (is.object(options.joi)) {
+            options.joi = extend(true, joiOptionsDefault, options.joi);
+        } else {
+            options.joi = joiOptionsDefault;
+        }
+        if (!Object.prototype.hasOwnProperty.call(options.joi.options, 'stripUnknown')) {
+            options.joi.options.stripUnknown = options.joi.options.allowUnknown !== true;
+        }
+    }
     return options;
 }
 
 function buildJoiSchema(schema, joiConfig) {
-    if (is.undef(joiConfig)) {
+    if (!is.object(joiConfig)) {
         return undefined;
     }
 
-    const hasExtra = is.object(joiConfig) && is.object(joiConfig.extra);
+    const hasExtra = is.object(joiConfig.extra);
     const joiKeys = {};
 
     Object.keys(schema).forEach((k) => {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -10,6 +10,7 @@ const Joi = optional('joi');
 
 const { queries } = require('./constants');
 const VirtualType = require('./virtualType');
+const { ValidationError, errorCodes } = require('./errors');
 
 const IS_QUERY_HOOK = {
     update: true,
@@ -165,7 +166,24 @@ class Schema {
         }
         return this.virtuals[propName];
     }
+
+    validateJoi(entityData) {
+        if (!this.isJoi) {
+            return {
+                error: new ValidationError(
+                    errorCodes.ERR_GENERIC,
+                    'Schema does not have a joi configuration object'
+                ),
+                value: entityData,
+            };
         }
+        return this._joi.validate(entityData, this.options.joi.options || {});
+    }
+
+    get isJoi() {
+        return !is.undef(this._joi);
+    }
+}
 
 /**
  * Static properties

--- a/test/model-test.js
+++ b/test/model-test.js
@@ -208,6 +208,22 @@ describe('Model', () => {
             assert.isDefined(entityData.unknown);
         });
 
+        it('should return the same value object from Model.sanitize and Entity.validate in Joi schema', () => {
+            schema = new Schema({
+                foo: { joi: Joi.object({ bar: Joi.any() }).required() },
+                createdOn: { joi: Joi.date().default(() => new Date('01-01-2019'), 'static createdOn date') },
+            }, { joi: true });
+            GstoreModel = gstore.model('BlogJoi', schema, gstore);
+
+            const data = { foo: { unknown: 123 } };
+            const entityData = GstoreModel.sanitize(data);
+            const { value: validationData, error: validationError } = new GstoreModel(data).validate();
+
+            assert.isUndefined(entityData.foo.unknown);
+            assert.isNull(validationError);
+            assert.deepEqual(entityData, validationData);
+        });
+
         it('should preserve the datastore.KEY', () => {
             const key = GstoreModel.key(123);
             let data = { foo: 'bar' };


### PR DESCRIPTION
We are using gstore-node in a project and I experienced a bug where my Schema would validate and could be saved but the default values of my schema would not be applied. 
After debugging I found the culprit to be the following statement in the `validate` function:
```
joiOptions.stripUnknown = {}.hasOwnProperty.call(joiOptions, 'stripUnknown')	
            ? joiOptions.stripUnknown	
            : schema.options.explicitOnly !== false;
```
This default argument logic is only applied when validating and not during sanitisation causing the sanitisation to error but the validation to complete with no error. Since the entity data is only changed using the sanitisation some Joi logic is not executed during sanitisation because of the ignored error. I've included a test case to reproduce this problem.

To correctly fix this error I needed to interpret the expected default behaviour for Joi schema validation. My interpretation resulted in the following assumptions:
 - if `explicitOnly` is not set the options should default to `true` (previously this option remained `undefined` or `null` which was as `true`)
- `joi.options.allowUnknown` will default to false when explicitOnly is true, otherwise it will default to true
- `joi.options.stripUnknown` will default to false when allowUnknown is true, otherwise it will default to true

This behaviour results in the following default settings when `{ joi: true }` is given: `{ explicitOnly: true, joi: { options: { allowUnknown: false, stripUnknown: true } } }`

Note that this PR could produce breaking behaviour when someone relies on explicitly setting `explicitOnly` to `null` or `undefined` since this will be treated as `false` instead of `true` after this PR. However, I would assume this behaviour is not used since it could be confusing since normally `null` and `undefined` are treated as falsy.