### PR TITLE
fix: call execPostHooks on internalTransaction

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -319,7 +319,14 @@ class Model extends Entity {
             if (internalTransaction) {
                 // If we created the Transaction instance internally for the update, we commit it
                 // otherwise we leave the commit() call to the transaction creator
-                return transaction.commit().then(onTransactionSuccess);
+                return transaction
+                    .commit()
+                    .then(() => transaction.execPostHooks().catch((err) => {
+                        entityUpdated[
+                            entityUpdated.gstore.ERR_HOOKS
+                        ] = (entityUpdated[entityUpdated.gstore.ERR_HOOKS] || []).push(err);
+                    }))
+                    .then(onTransactionSuccess);
             }
 
             return onTransactionSuccess();


### PR DESCRIPTION
I noticed that when using an internalTransaction (the default behaviour when no transaction is given) for the `update` method the `transaction.execPostHooks` function is never called.
I fixed this by adding a line to the `internalTransaction` check and appending errors to `entity[ERR_HOOKS]`

I initially tried to add a test but found it non-trivial to mock the `transaction` used in the `update` method.