### PR TITLE
Feat/hapi  joi package support

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -6,7 +6,7 @@ const optional = require('optional');
 const extend = require('extend');
 const is = require('is');
 
-const Joi = optional('joi');
+const Joi = optional('@hapi/joi') || optional('joi');
 
 const { queries } = require('./constants');
 const VirtualType = require('./virtualType');

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "eslint-import-resolver-webpack": "^0.11.0",
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-mocha": "^5.2.1",
-    "joi": "^12.0.0",
+    "@hapi/joi": "^15.0.3",
     "mocha": "^5.2.0",
     "mocha-lcov-reporter": "^1.3.0",
     "nconf": "^0.10.0",

--- a/test/entity-test.js
+++ b/test/entity-test.js
@@ -2,7 +2,7 @@
 
 const chai = require('chai');
 const sinon = require('sinon');
-const Joi = require('joi');
+const Joi = require('@hapi/joi');
 const { Datastore } = require('@google-cloud/datastore');
 
 const ds = new Datastore({

--- a/test/helpers/validation-test.js
+++ b/test/helpers/validation-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const chai = require('chai');
-const Joi = require('joi');
+const Joi = require('@hapi/joi');
 
 const Schema = require('../../lib/schema');
 const gstoreErrors = require('../../lib/errors');

--- a/test/integration/model.js
+++ b/test/integration/model.js
@@ -5,7 +5,7 @@
 const chai = require('chai');
 const sinon = require('sinon');
 const Chance = require('chance');
-const Joi = require('joi');
+const Joi = require('@hapi/joi');
 const { Datastore } = require('@google-cloud/datastore');
 const { argv } = require('yargs');
 

--- a/test/model-test.js
+++ b/test/model-test.js
@@ -4,7 +4,7 @@
 const chai = require('chai');
 const sinon = require('sinon');
 const is = require('is');
-const Joi = require('joi');
+const Joi = require('@hapi/joi');
 
 const { Gstore } = require('../lib');
 const Entity = require('../lib/entity');

--- a/test/schema-test.js
+++ b/test/schema-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const chai = require('chai');
-const Joi = require('joi');
+const Joi = require('@hapi/joi');
 
 const { Gstore } = require('../lib');
 const ds = require('./mocks/datastore')();

--- a/test/serializers/datastore-test.js
+++ b/test/serializers/datastore-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const chai = require('chai');
-const Joi = require('joi');
+const Joi = require('@hapi/joi');
 
 const { Gstore } = require('../../lib');
 const ds = require('../mocks/datastore')({

--- a/yarn.lock
+++ b/yarn.lock
@@ -135,6 +135,32 @@
     lodash "^4.17.5"
     protobufjs "^6.8.6"
 
+"@hapi/address@2.x.x":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.0.0.tgz#9f05469c88cb2fd3dcd624776b54ee95c312126a"
+  integrity sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw==
+
+"@hapi/hoek@6.x.x":
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-6.2.3.tgz#0abff7ac75d0c5388d2829c464b2aff74d473721"
+  integrity sha512-CtV9cp35+6Sfh6OfB+AYBozNIorZ6npNJjfO8InIyh/iFQI7uBW9bIApYoYf6TWq9w9BArecw2DDJf7oK+VlRw==
+
+"@hapi/joi@^15.0.3":
+  version "15.0.3"
+  resolved "https://registry.yarnpkg.com/@hapi/joi/-/joi-15.0.3.tgz#e94568fd859e5e945126d5675e7dd218484638a7"
+  integrity sha512-z6CesJ2YBwgVCi+ci8SI8zixoj8bGFn/vZb9MBPbSyoxsS2PnWYjHcyTM17VLK6tx64YVK38SDIh10hJypB+ig==
+  dependencies:
+    "@hapi/address" "2.x.x"
+    "@hapi/hoek" "6.x.x"
+    "@hapi/topo" "3.x.x"
+
+"@hapi/topo@3.x.x":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-3.1.0.tgz#5c47cd9637c2953db185aa957a27bcb2a8b7a6f8"
+  integrity sha512-gZDI/eXOIk8kP2PkUKjWu9RW8GGVd2Hkgjxyr/S7Z+JF+0mr7bAlbw+DkTRxnD580o8Kqxlnba9wvqp5aOHBww==
+  dependencies:
+    "@hapi/hoek" "6.x.x"
+
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
@@ -3033,11 +3059,6 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoek@4.x.x:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
-  integrity sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==
-
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -3474,13 +3495,6 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
-isemail@3.x.x:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/isemail/-/isemail-3.2.0.tgz#59310a021931a9fb06bbb51e155ce0b3f236832c"
-  integrity sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==
-  dependencies:
-    punycode "2.x.x"
-
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
@@ -3554,15 +3568,6 @@ istanbul-reports@^2.0.1:
   integrity sha512-CT0QgMBJqs6NJLF678ZHcquUAZIoBIUNzdJrRJfpkI9OnzG6MkUfHxbJC3ln981dMswC7/B1mfX3LNkhgJxsuw==
   dependencies:
     handlebars "^4.0.11"
-
-joi@^12.0.0:
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/joi/-/joi-12.0.0.tgz#46f55e68f4d9628f01bbb695902c8b307ad8d33a"
-  integrity sha512-z0FNlV4NGgjQN1fdtHYXf5kmgludM65fG/JlXzU6+rwkt9U5UWuXVYnXa2FpK0u6+qBuCmrm5byPNuiiddAHvQ==
-  dependencies:
-    hoek "4.x.x"
-    isemail "3.x.x"
-    topo "2.x.x"
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -4998,15 +5003,15 @@ punycode@1.3.2:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
   integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
 
-punycode@2.x.x, punycode@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
-  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
-
 punycode@^1.2.4, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
+
+punycode@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
 q@^1.4.1, q@^1.5.1:
   version "1.5.1"
@@ -5985,13 +5990,6 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
-
-topo@2.x.x:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/topo/-/topo-2.0.2.tgz#cd5615752539057c0dc0491a621c3bc6fbe1d182"
-  integrity sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=
-  dependencies:
-    hoek "4.x.x"
 
 tough-cookie@~2.4.3:
   version "2.4.3"


### PR DESCRIPTION
I received a deprecation warning while deploying my app with `joi` as a dependency. It seems the package has been migrated to the `@hapi/joi` package and `joi` is no longer maintained.

Therefore I updated the `joi` package in de devDependencies to use `@hapi/joi` and added an optional import to `@hapi/joi`.

I did not find any breaking changes from `joi v14.x.x` which I was using previously and `@hapi/joi v15.x.x`.
