### PR TITLE
Fix Schema#methods .d.ts signature

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -134,7 +134,7 @@ export class Schema<T = { [key: string]: any }> {
     * }
     * ```
     */
-    readonly methods: { [propName: string]: () => any };
+    readonly methods: { [propName: string]: (...args: any[]) => any };
 
     /**
      * Getter / Setter for Schema paths.


### PR DESCRIPTION
This allows for any kind of method signature under Typescript as [per the docs](https://sebloix.gitbook.io/gstore-node/schema/custom-methods).