### PR TITLE
Entity Keys: remove convertion of id string to integer

### DIFF
--- a/lib/entity.js
+++ b/lib/entity.js
@@ -318,6 +318,10 @@ class Entity {
 // Private
 // -------
 function createKey(self, id, ancestors, namespace) {
+    if (id && !is.number(id) && !is.string(id)) {
+        throw new Error('id must be a string or a number');
+    }
+
     const hasAncestors = typeof ancestors !== 'undefined' && ancestors !== null && is.array(ancestors);
 
     /*
@@ -329,7 +333,6 @@ function createKey(self, id, ancestors, namespace) {
 
     let path;
     if (id) {
-        id = parseId(self, id);
         path = hasAncestors ? ancestors.concat([self.entityKind, id]) : [self.entityKind, id];
     } else {
         if (hasAncestors) {
@@ -342,32 +345,6 @@ function createKey(self, id, ancestors, namespace) {
         path = [path];
     }
     return namespace ? self.gstore.ds.key({ namespace, path }) : self.gstore.ds.key(path);
-}
-
-/**
- * Parse the id and according to the keyType config in the Schema ("name"|"id"|<undefined>)
- * it will convert an '123'(string) id to 123 (int).
- * @param {*} self -- the entity instance
- * @param {*} id -- id passed in constructor
- */
-function parseId(self, id) {
-    const { options } = self.schema;
-
-    if (is.string(id)) {
-        if (options && options.keyType === 'name') {
-            return id;
-        } if (options.keyType === 'id') {
-            return self.gstore.ds.int(id);
-        }
-        // auto convert string number to number
-        return isFinite(id) ? self.gstore.ds.int(id) : id;
-    }
-
-    if (!is.number(id)) {
-        throw new Error('id must be a string or a number');
-    }
-
-    return id;
 }
 
 function buildEntityData(self, data) {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -187,7 +187,7 @@ export class Schema<T = { [key: string]: any }> {
 
     /**
      * Executes joi.validate on given data. If schema does not have a joi config object data is returned
-     * 
+     *
      * @param {*} data The data to sanitize
      * @returns {*} The data sanitized
      */
@@ -755,7 +755,6 @@ export interface SchemaOptions {
         format?: JSONFormatType | EntityFormatType;
         showKey?: string;
     };
-    keyType?: "id" | "name" | "auto";
     joi?: boolean | { extra?: any; options?: any };
 }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -132,10 +132,8 @@ class Model extends Entity {
      * Get and entity from the Datastore
      */
     static get(id, ancestors, namespace, transaction, options = {}) {
-        let ids = arrify(id);
+        const ids = arrify(id);
         const _this = this;
-
-        ids = ids.map(parseId);
 
         const key = this.key(ids, ancestors, namespace);
         const refsToPopulate = [];
@@ -225,8 +223,6 @@ class Model extends Entity {
 
         let entityUpdated;
         let error = {};
-
-        id = parseId(id);
 
         const key = this.key(id, ancestors, namespace);
         const replace = options && options.replace === true;
@@ -378,10 +374,6 @@ class Model extends Entity {
     static delete(id, ancestors, namespace, transaction, key, options = {}) {
         const _this = this;
         this.__hooksEnabled = true;
-
-        const multiple = is.array(id);
-
-        id = multiple ? id.map(parseId) : parseId(id);
 
         if (!key) {
             key = this.key(id, ancestors, namespace);
@@ -587,7 +579,6 @@ class Model extends Entity {
             let path = [_this.entityKind];
 
             if (typeof id !== 'undefined' && id !== null) {
-                id = parseId(id);
                 path.push(id);
             }
 
@@ -899,7 +890,7 @@ class Model extends Entity {
          * For "multiple" ids to delete, we obviously can't set any scope.
          */
         function getScopeForDeleteHooks() {
-            let id = is.object(args[0]) && {}.hasOwnProperty.call(args[0], '__override')
+            const id = is.object(args[0]) && {}.hasOwnProperty.call(args[0], '__override')
                 ? arrify(args[0].__override)[0]
                 : args[0];
 
@@ -907,7 +898,6 @@ class Model extends Entity {
                 return null;
             }
 
-            id = parseId(id);
             let ancestors;
             let namespace;
             let key;
@@ -982,10 +972,6 @@ function applyStatics(_Model, schema) {
         _Model[method] = schema.statics[method];
     });
     return _Model;
-}
-
-function parseId(id) {
-    return id !== null && isFinite(id) ? parseInt(id, 10) : id;
 }
 
 // Bind Query methods

--- a/test/entity-test.js
+++ b/test/entity-test.js
@@ -231,18 +231,6 @@ describe('Entity', () => {
 
             it('---> with a full Key ("string" Integer keyname passed)', () => {
                 entity = new GstoreModel({}, '123');
-
-                expect(entity.entityKey.id).equal('123');
-            });
-
-            it('---> with a full Key ("string" Integer **not** converted)', () => {
-                schema = new Schema({
-                    name: { type: 'string' },
-                }, { keyType: 'name' });
-                GstoreModel = gstore.model('EntityKind', schema);
-
-                entity = new GstoreModel({}, '123');
-
                 expect(entity.entityKey.name).equal('123');
             });
 

--- a/test/integration/cache.js
+++ b/test/integration/cache.js
@@ -4,13 +4,14 @@
 
 const redisStore = require('cache-manager-redis-store');
 const chai = require('chai');
+const Chance = require('chance');
 const { Datastore } = require('@google-cloud/datastore');
 const { argv } = require('yargs');
 
 const { Gstore } = require('../../lib');
 
 const ds = new Datastore({ projectId: 'gstore-integration-tests' });
-
+const chance = new Chance();
 const { expect } = chai;
 
 const allKeys = [];
@@ -74,11 +75,11 @@ describe('Integration Tests (Cache)', () => {
     });
 
     it('should set KEY symbol on query result', () => {
-        const user = new Model({ email: 'test@test.com' });
-
+        const id = chance.string({ pool: 'abcdefghijklmnopqrstuvwxyz0123456789' });
+        const user = new Model({ email: 'test@test.com' }, id);
         return user.save().then(entity => {
             addKey(entity.entityKey);
-            return Model.get(entity.entityKey.id)
+            return Model.get(entity.entityKey.name)
                 .then(e => {
                     expect(e.email).equal('test@test.com');
                 });

--- a/test/model-test.js
+++ b/test/model-test.js
@@ -286,11 +286,6 @@ describe('Model', () => {
             assert.isUndefined(key.path[1]);
         });
 
-        it('should parse string id "123" to integer', () => {
-            const key = GstoreModel.key('123');
-            expect(key.path[1]).equal(123);
-        });
-
         it('should create array of ids', () => {
             const keys = GstoreModel.key([22, 69]);
 
@@ -360,11 +355,6 @@ describe('Model', () => {
             .then(_entity => {
                 assert.isTrue(is.array(_entity));
             }));
-
-        it('converting a string integer to real integer', () => GstoreModel.get('123').then(() => {
-            assert.isUndefined(ds.get.getCall(0).args[0].name);
-            expect(ds.get.getCall(0).args[0][0].id).equal(123);
-        }));
 
         it('not converting string with mix of number and non number', () => GstoreModel.get('123:456').then(() => {
             expect(ds.get.getCall(0).args[0][0].name).equal('123:456');


### PR DESCRIPTION
The live Datastore treats the same way User.get("123") than User.get(123). Both return the entity
with the Key.id being "123". The conversion from string to integer has been removed inside gstore
and let to the consumer to implement if needed.

**BREAKING CHANGE**: The "keyType" Schema option has been removed as it is no longer needed. Also, as gstore does not parse the id anymore, running your project against the **local Datastore emulator** might break as the emulator treats differently `User.get(123)` than `User.get("123")`. Auto-allocated ids are integers and need to be provided as integers to the Emulator.

Fixes https://github.com/sebelga/gstore-node/issues/168