### PR TITLE
Add Schema option to support auto unindex

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -750,6 +750,7 @@ export interface SchemaPathDefinition {
 export interface SchemaOptions {
     validateBeforeSave?: boolean;
     explicitOnly?: boolean;
+    excludeLargeProperties?: boolean;
     queries?: {
         readAll?: boolean;
         format?: JSONFormatType | EntityFormatType;

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -202,6 +202,7 @@ function defaultOptions(options) {
     const optionsDefault = {
         validateBeforeSave: true,
         explicitOnly: true,
+        excludeLargeProperties: false,
         queries: {
             readAll: false,
             format: queries.formats.JSON,

--- a/lib/serializers/datastore.js
+++ b/lib/serializers/datastore.js
@@ -21,6 +21,7 @@ function toDatastore(entity, options = {}) {
     const datastoreFormat = {
         key: entity.entityKey,
         data,
+        excludeLargeProperties: entity.schema.options.excludeLargeProperties,
     };
 
     if (excludeFromIndexes.length > 0) {

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -190,7 +190,7 @@ describe('gstore-node', () => {
                 const { args } = ds.save.getCall(0);
                 const firstEntity = args[0][0];
                 assert.isUndefined(firstEntity.className);
-                expect(Object.keys(firstEntity)).deep.equal(['key', 'data']);
+                expect(Object.keys(firstEntity)).deep.equal(['key', 'data', 'excludeLargeProperties']);
             });
         });
 

--- a/test/serializers/datastore-test.js
+++ b/test/serializers/datastore-test.js
@@ -122,8 +122,9 @@ describe('Datastore serializer', () => {
                 array2: [1, 2, 3],
                 array: null,
             };
-            const { data } = datastoreSerializer.toDatastore(entity);
+            const { data, excludeLargeProperties } = datastoreSerializer.toDatastore(entity);
             expect(data).to.deep.equal(expected);
+            expect(excludeLargeProperties).to.equal(false);
         });
 
         it('not taking into account "undefined" variables', () => {
@@ -134,6 +135,15 @@ describe('Datastore serializer', () => {
         it('and set excludeFromIndexes properties', () => {
             const { excludeFromIndexes } = datastoreSerializer.toDatastore(entity);
             expect(excludeFromIndexes).to.deep.equal(['name', 'embedded.description', 'array2[]', 'array2[].*']);
+        });
+
+        it('and set excludeLargeProperties flag', () => {
+            const schema = new Schema({ name: String }, { excludeLargeProperties: true });
+            const Model = gstore.model('Serializer-auto-unindex', schema);
+            entity = new Model({ name: 'John' });
+
+            const { excludeLargeProperties } = datastoreSerializer.toDatastore(entity);
+            expect(excludeLargeProperties).equal(true);
         });
 
         it('should set all excludeFromIndexes on all properties of object', () => {


### PR DESCRIPTION
Since version 4.3 of the Datastore client, you can specify that large properties are automatically
not indexed. https://github.com/googleapis/nodejs-datastore/pull/453

This PR adds a new `excludeLargeProperties` option for the Schema that you can set to true to benefit from this new feature.