### PR TITLE
fix(gstore.save()): update "modifiedOn" property on entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [**Support**](../../issues) |
 [**Changelog**](../../releases)
 
-gstore-node is a Google Datastore entities modeling library for Node.js inspired by Mongoose and built **on top** of the **[@google-cloud/datastore](https://googlecloudplatform.github.io/google-cloud-node/#/docs/datastore/master/datastore)** library.  
+gstore-node is a Google Datastore entities modeling library for Node.js inspired by Mongoose and built **on top** of the **[@google-cloud/datastore](https://googleapis.dev/nodejs/datastore/latest/index.html)** client.  
 It is not a replacement of @google-cloud/datastore but a layer on top of it to help modeling your entities through Schemas and to help validating the data saved in the Datastore.
 
 ## Highlight

--- a/src/helpers/validation.test.ts
+++ b/src/helpers/validation.test.ts
@@ -21,11 +21,6 @@ const customValidationFunction = (obj: any, validator: any, min: number, max: nu
   return false;
 };
 
-/**
- * These are the new Types for the Schemas
- * To be backward compatible, the old types ('int', 'string') are still supported.
- * Once they will be deprecated we can delete the Validation (old Types) below.
- */
 describe('Validation', () => {
   let schema: Schema;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -180,24 +180,25 @@ export class Gstore {
       throw new Error('No entities passed');
     }
 
-    // Validate entities before saving
-    if (options.validate) {
-      let error;
-      const validateEntity = (entity: GstoreEntity): void => {
-        ({ error } = entity.validate());
+    const serializeAndValidateEntity = (entity: GstoreEntity): void => {
+      entity.__serializeEntityData();
+
+      if (options.validate) {
+        const { error } = entity.validate();
         if (error) {
           throw error;
         }
-      };
-      try {
-        if (Array.isArray(entities)) {
-          entities.forEach(validateEntity);
-        } else {
-          validateEntity(entities);
-        }
-      } catch (err) {
-        return Promise.reject(err);
       }
+    };
+
+    try {
+      if (Array.isArray(entities)) {
+        entities.forEach(serializeAndValidateEntity);
+      } else {
+        serializeAndValidateEntity(entities);
+      }
+    } catch (err) {
+      return Promise.reject(err);
     }
 
     // Convert gstore entities to datastore forma ({key, data})


### PR DESCRIPTION
When entities have a "modifiedOn" property declared on their schema, saving the entity (with
entity.save() or gstore.save()) will update update the property with the current time.

fix #202