### PR TITLE
fix(typings): Pass the extended Entity type to custom entity functions

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import { entity } from '@google-cloud/datastore/build/src/entity';
-import GstoreEntity from './entity';
+import GstoreEntity, { Entity } from './entity';
 
 export type EntityKey = entity.Key;
 
@@ -9,7 +9,7 @@ export type FuncReturningPromise = (...args: any[]) => Promise<any>;
 
 export type FunctionType = (...args: any[]) => any;
 
-export type CustomEntityFunction<T extends object> = (this: GstoreEntity<T>, ...args: any[]) => any;
+export type CustomEntityFunction<T extends object> = (this: Entity<T>, ...args: any[]) => any;
 
 export type GenericObject = { [key: string]: any };
 


### PR DESCRIPTION
This fixes custom schema functions being passed the base Entity type instead of the extended Entity type return when instantiating an entity from a model.

For example, taking the first piece of code on the [custom methods doc](https://sebloix.gitbook.io/gstore-node/schema/custom-methods) and adding types to it it would have been:

```typescript
const blogPostSchema = new Schema({ title: {} });

// Custom method to retrieve all children Text entities
blogPostSchema.methods.texts = function getTexts(this: GstoreEntity<T>) {
   // ...
};
```

Because the custom method is passed a `GstoreEntity`, it means virtual properties are not typed on `this`. This PR fixes this.