### PR TITLE
fix(typings): Fix passing of generic parameters to Entity

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -40,7 +40,7 @@ export interface Model<
   T extends object = GenericObject,
   M extends object = { [key: string]: CustomEntityFunction<T> }
 > {
-  new (data?: EntityData<T>, id?: IdType, ancestors?: Ancestor, namespace?: string, key?: EntityKey): Entity<T>;
+  new (data?: EntityData<T>, id?: IdType, ancestors?: Ancestor, namespace?: string, key?: EntityKey): Entity<T, M>;
 
   /**
    * The gstore instance
@@ -91,7 +91,7 @@ export interface Model<
     namespace?: string,
     transaction?: Transaction,
     options?: GetOptions,
-  ): PromiseWithPopulate<U extends Array<string | number> ? Entity<T>[] : Entity<T>>;
+  ): PromiseWithPopulate<U extends Array<string | number> ? Entity<T, M>[] : Entity<T, M>>;
 
   /**
    * Update an Entity in the Datastore. This method _partially_ updates an entity data in the Datastore
@@ -114,7 +114,7 @@ export interface Model<
     namespace?: string,
     transaction?: Transaction,
     options?: GenericObject,
-  ): Promise<Entity<T>>;
+  ): Promise<Entity<T, M>>;
 
   /**
    * Delete an Entity from the Datastore
@@ -191,7 +191,7 @@ export interface Model<
    */
   query<
     F extends JSONFormatType | EntityFormatType = JSONFormatType,
-    R = F extends EntityFormatType ? QueryResponse<T, Entity<T>[]> : QueryResponse<T, EntityData<T>[]>
+    R = F extends EntityFormatType ? QueryResponse<T, Entity<T, M>[]> : QueryResponse<T, EntityData<T>[]>
   >(
     namespace?: string,
     transaction?: Transaction,

--- a/src/query.ts
+++ b/src/query.ts
@@ -99,9 +99,10 @@ class Query<T extends object, M extends object> {
     return (query as unknown) as GstoreQuery<T, R>;
   }
 
-  list<U extends QueryListOptions<T>, Outputformat = U['format'] extends EntityFormatType ? Entity<T, M> : EntityData<T>>(
-    options: U = {} as U,
-  ): PromiseWithPopulate<QueryResponse<T, Outputformat[]>> {
+  list<
+    U extends QueryListOptions<T>,
+    Outputformat = U['format'] extends EntityFormatType ? Entity<T, M> : EntityData<T>
+  >(options: U = {} as U): PromiseWithPopulate<QueryResponse<T, Outputformat[]>> {
     // If global options set in schema, we extend it with passed options
     if ({}.hasOwnProperty.call(this.Model.schema.shortcutQueries, 'list')) {
       options = extend({}, this.Model.schema.shortcutQueries.list, options);

--- a/src/query.ts
+++ b/src/query.ts
@@ -99,7 +99,7 @@ class Query<T extends object, M extends object> {
     return (query as unknown) as GstoreQuery<T, R>;
   }
 
-  list<U extends QueryListOptions<T>, Outputformat = U['format'] extends EntityFormatType ? Entity<T> : EntityData<T>>(
+  list<U extends QueryListOptions<T>, Outputformat = U['format'] extends EntityFormatType ? Entity<T, M> : EntityData<T>>(
     options: U = {} as U,
   ): PromiseWithPopulate<QueryResponse<T, Outputformat[]>> {
     // If global options set in schema, we extend it with passed options
@@ -125,7 +125,7 @@ class Query<T extends object, M extends object> {
       cache?: boolean;
       ttl?: number | { [key: string]: number };
     },
-  ): PromiseWithPopulate<Entity<T> | null> {
+  ): PromiseWithPopulate<Entity<T, M> | null> {
     this.Model.__hooksEnabled = true;
 
     if (!is.object(keyValues)) {
@@ -134,7 +134,7 @@ class Query<T extends object, M extends object> {
       >;
     }
 
-    const query = this.initQuery<Entity<T> | null>(namespace);
+    const query = this.initQuery<Entity<T, M> | null>(namespace);
     query.limit(1);
 
     Object.keys(keyValues).forEach(k => {
@@ -145,7 +145,7 @@ class Query<T extends object, M extends object> {
       query.hasAncestor(this.Model.gstore.ds.key(ancestors.slice()));
     }
 
-    const responseHandler = ({ entities }: QueryResponse<T>): Entity<T> | null => {
+    const responseHandler = ({ entities }: QueryResponse<T>): Entity<T, M> | null => {
       if (entities.length === 0) {
         if (this.Model.gstore.config.errorOnEntityNotFound) {
           throw new GstoreError(ERROR_CODES.ERR_ENTITY_NOT_FOUND, `${this.Model.entityKind} not found`);
@@ -177,7 +177,7 @@ class Query<T extends object, M extends object> {
    */
   findAround<
     U extends QueryFindAroundOptions,
-    Outputformat = U['format'] extends EntityFormatType ? Entity<T> : EntityData<T>
+    Outputformat = U['format'] extends EntityFormatType ? Entity<T, M> : EntityData<T>
   >(property: keyof T, value: any, options: U, namespace?: string): PromiseWithPopulate<Outputformat[]> {
     const validateArguments = (): { error: Error | null } => {
       if (!property || !value || !options) {


### PR DESCRIPTION
Only one of the generic parameters were passed in  contexts where both generic parameters of Entity are available.

Related: #220 