### PR TITLE
docs(github issue templates): add github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,51 @@
+---
+name: 🐛 Reporting a Bug
+about: Open a new issue here if something isn't working as expected.
+---
+
+<!--
+
+Thanks for filing an issue on gstore-node!
+
+Before reporting a bug, please first check for existing or closed issues.
+
+### This bug report should include:
+
+- [ ] A short, but descriptive title.
+- [ ] The environment used (OS version, node version, gstore-node package version)
+- [ ] If applicable, the last version of gstore-node where the problem did _not_ occur.
+- [ ] The expected behavior.
+- [ ] The actual behavior.
+- [ ] A **simple**, runnable reproduction.
+
+  Please make sure that you include the following information to ensure that your issue is actionable.
+
+  If you don't follow the template, your issue may end up being closed without anyone looking at it carefully, because it is not actionable for us without the information in this template.
+
+-->
+
+## Description
+
+Briefly describe the issue
+
+## Environment
+
+* OS - OS name and version
+* node - node version
+* gstore-node - package version
+
+## Expected behavior
+
+Describe what you expected to happen
+
+## Actual behavior
+
+Describe what actually happened
+
+## Reproduction
+
+Briefly describe the steps to recreate the issue as well as a simple code example.
+
+## Possible solution
+
+If available describe how you think the issue can be resolved.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,36 @@
+---
+name: ✏️ Reporting a Documentation issue
+about: Open a new issue here if the documentation isn't as expected.
+---
+
+<!--
+
+Thanks for filing an issue on gstore-node!
+
+Before reporting a documentation issue, please first check for existing or closed issues.
+
+### This documentation issue report should include:
+
+- [ ] A short, but descriptive title.
+- [ ] Links to the appropriate documentation pages.
+- [ ] Suggestions on how to improve the documentation.
+
+-->
+
+## Description 
+
+A clear and concise description of the issue. Please include quotes or references to line numbers if applicable, and state which of the following applies (if any):
+
+* Something is unclear
+* Something is missing
+* Something is inaccurate
+* Something needs elaboration
+* Something needs more examples
+
+## Links
+
+Please provide links to the appropriate documentation pages from https://sebloix.gitbook.io/gstore-node/.
+
+## Ways to improve 
+
+Please suggest language or other means by which this can be improved

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,41 @@
+---
+name: 🚀 Feature Request
+about: Have a feature that you think is important? Help us understand it.
+---
+
+<!--
+
+- Prior to opening a feature request, please search for existing requests.
+
+  If you find an existing feature that matches your needs, use the 👍 emote
+  to show your support for it. If the specifics of your use case are not
+  covered in the existing feature request but the idea seems similar enough,
+  please take the time to *add new conversation* which helps the feature's
+  design evolve.
+
+- If you do not find any other existing requests for the feature you desire,
+  you should open a new feature request. Please take the time to help us
+  understand your use-case as precisely as possible. Be sure to demonstrate
+  that you've evaluated existing features and found them unsuitable and were
+  unable to implement the functionality with the plugin API.
+
+  Be flexible in your design and consider slight variations which might
+  necessitate a specific API design.
+
+-->
+
+## Related Issues
+
+* Add any related issues here
+
+## Motivation
+
+Describe the goal of this feature request and what use case it is meant to resolve
+
+## Proposed solution
+
+Add any proposed solution you have already started to work on or thought about.
+
+## Sample code
+
+Provide (pseudo) code of how the added feature would be used


### PR DESCRIPTION
Add issue templates to the repo to guide users on the information required for new issues