### PR TITLE
Casting to datastore key on convertToEntity for entity from cache

### DIFF
--- a/src/serializers/datastore.ts
+++ b/src/serializers/datastore.ts
@@ -118,8 +118,9 @@ const fromDatastore = <F extends 'JSON' | 'ENTITY' = 'JSON', R = F extends 'ENTI
 
   const convertToEntity = (): GstoreEntity => {
     const _key: EntityKey = entityData[Model.gstore.ds.KEY as any];
-    if (!Model.gstore.ds.isKey(_key)) { // for entity from cache
-      entityData[Model.gstore.ds.KEY as any] = Model.gstore.ds.key(_key)
+    if (!Model.gstore.ds.isKey(_key)) {
+      // for entity from cache
+      entityData[Model.gstore.ds.KEY as any] = Model.gstore.ds.key(_key);
     }
     const key: EntityKey = entityData[Model.gstore.ds.KEY as any];
     return new Model(entityData, undefined, undefined, undefined, key);

--- a/src/serializers/datastore.ts
+++ b/src/serializers/datastore.ts
@@ -117,6 +117,10 @@ const fromDatastore = <F extends 'JSON' | 'ENTITY' = 'JSON', R = F extends 'ENTI
   };
 
   const convertToEntity = (): GstoreEntity => {
+    const _key: EntityKey = entityData[Model.gstore.ds.KEY as any];
+    if (!Model.gstore.ds.isKey(_key)) { // for entity from cache
+      entityData[Model.gstore.ds.KEY as any] = Model.gstore.ds.key(_key)
+    }
     const key: EntityKey = entityData[Model.gstore.ds.KEY as any];
     return new Model(entityData, undefined, undefined, undefined, key);
   };


### PR DESCRIPTION
Casting object to datastore key when get entities with query from cache
(key is vanilla object when hit cache)


Related : https://github.com/sebelga/gstore-node/issues/243

