### PR TITLE
feat(query): add transaction parameter to `findOne`

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -126,6 +126,7 @@ class Query<T extends object, M extends object> {
       cache?: boolean;
       ttl?: number | { [key: string]: number };
     },
+    transaction?: Transaction,
   ): PromiseWithPopulate<Entity<T, M> | null> {
     this.Model.__hooksEnabled = true;
 
@@ -135,7 +136,7 @@ class Query<T extends object, M extends object> {
       >;
     }
 
-    const query = this.initQuery<Entity<T, M> | null>(namespace);
+    const query = this.initQuery<Entity<T, M> | null>(namespace, transaction);
     query.limit(1);
 
     Object.keys(keyValues).forEach((k) => {


### PR DESCRIPTION
This adds `Transaction` support to `findOne` method.
Now users would be able to make more requests to Datastore using one Transaction.

Closes #260 